### PR TITLE
`MockIMU` log path change, pretty print mock sim 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ However during development, you may want to run individual scripts to test compo
 To run a simulation, make sure to first specify the path to the csv file in `constants.py` and then run:
 ```python3 main.py mock```
 
-This will run the program with the mock data. You many need to adjust `mock_imu.py` according to the data structure of the csv file.
+This will run the program with the mock data, with values of the simulation printed in real time. You many need to adjust `mock_imu.py` according to the data structure of the csv file.
 
 ### Contributing
 Feel free to submit issues or pull requests. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -85,5 +85,10 @@ To run the main program, simply run:
 However during development, you may want to run individual scripts to test components. For example, to test the servo, run:
 ```python3 -m scripts.run_servo```
 
+To run a simulation, make sure to first specify the path to the csv file in `constants.py` and then run:
+```python3 main.py mock```
+
+This will run the program with the mock data. You many need to adjust `mock_imu.py` according to the data structure of the csv file.
+
 ### Contributing
 Feel free to submit issues or pull requests. For major changes, please open an issue first to discuss what you would like to change.

--- a/airbrakes/mock/mock_imu.py
+++ b/airbrakes/mock/mock_imu.py
@@ -1,6 +1,7 @@
 """Module for simulating interacting with the IMU (Inertial measurement unit) on the rocket."""
 
 import csv
+import signal
 import time
 from pathlib import Path
 
@@ -31,6 +32,7 @@ class MockIMU(IMU):
         :param log_file_name: the name of the log file to read data from located in logs/
         :param frequency: Frequency in Hz for how often to pretend to fetch data
         """
+        signal.signal(signal.SIGINT, signal.SIG_IGN)  # Ignore the KeyboardInterrupt signal
 
         with log_file_path.open(newline="") as csvfile:
             reader = csv.DictReader(csvfile)

--- a/airbrakes/mock/mock_imu.py
+++ b/airbrakes/mock/mock_imu.py
@@ -15,7 +15,9 @@ class MockIMU(IMU):
     from a previous log file.
     """
 
-    def __init__(self, log_file_name: str, frequency: int):
+    __slots__ = ()
+
+    def __init__(self, log_file_name: Path, frequency: int):
         """
         Initializes the object that pretends to be an IMU for testing purposes by reading from a log file.
         :param log_file_name: The name of the log file to read data from.
@@ -23,15 +25,12 @@ class MockIMU(IMU):
         """
         super().__init__(log_file_name, frequency)
 
-    def _fetch_data_loop(self, log_file_name: str, _: int) -> None:
+    def _fetch_data_loop(self, log_file_path: Path, _: int) -> None:
         """
         Reads the data from the log file and puts it into the shared queue.
         :param log_file_name: the name of the log file to read data from located in logs/
         :param frequency: Frequency in Hz for how often to pretend to fetch data
         """
-
-        # Makes the path to the log file in an os-independent way
-        log_file_path = Path("logs") / log_file_name
 
         with log_file_path.open(newline="") as csvfile:
             reader = csv.DictReader(csvfile)

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -1,5 +1,14 @@
 """File which contains a few basic utility functions which can be reused in the project."""
 
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airbrakes.airbrakes import AirbrakesContext
+
+# ANSI escape code for cursor movement for printing simulation data:
+MOVE_CURSOR_UP = "\033[F"  # Move the cursor one line up
+
 
 def convert_to_nanoseconds(value) -> int:
     """Converts seconds to nanoseconds, if `value` is in float."""
@@ -42,3 +51,24 @@ def get_imu_data_processor_public_properties() -> list:
         "speed",
         "max_speed",
     ]
+
+
+def update_display(airbrakes: "AirbrakesContext", start_time: float):
+    """Prints the values from the simulation in a pretty way.
+
+    :param airbrakes: The airbrakes context object.
+    :param start_time: The time the simulation started, in seconds from epoch.
+    """
+    # Print values with multiple print statements
+    # The <10 is used to align the values to the left with a width of 10
+    # The .2f is used to format the float to 2 decimal places
+    print(f"Time since sim start:        {time.time() - start_time:<10.2f} s")
+    print(f"State:                       {airbrakes.state.name:<10}")
+    print(f"Current speed:               {airbrakes.data_processor.speed:<10.2f} m/s")
+    print(f"Max speed so far:            {airbrakes.data_processor.max_speed:<10.2f} m/s")
+    print(f"Current altitude:            {airbrakes.data_processor.current_altitude:<10.2f} m")
+    print(f"Max altitude so far:         {airbrakes.data_processor.max_altitude:<10.2f} m")
+    print(f"Current airbrakes extension: {airbrakes.current_extension:<10}")
+
+    # Move the cursor up 7 lines to overwrite the previous output
+    print(MOVE_CURSOR_UP * 7, end="", flush=True)

--- a/constants.py
+++ b/constants.py
@@ -11,7 +11,7 @@ from airbrakes.utils import get_imu_data_processor_public_properties
 
 # These are used for simulations
 MOCK_ARGUMENT = "mock"
-SIMULATION_LOG_NAME = "2023-12-16_17_11_35_mergedLORDlog.csv"  # This should be logged in the logs folder
+SIMULATION_LOG_PATH = Path("scripts/imu_data/winter_2023_launch_data.csv")
 
 # -------------------------------------------------------
 # Servo Configuration

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 loop."""
 
 import sys
+import time
 
 from gpiozero.pins.mock import MockFactory, MockPWMPin
 
@@ -11,6 +12,7 @@ from airbrakes.data_handling.logger import Logger
 from airbrakes.hardware.imu import IMU
 from airbrakes.hardware.servo import Servo
 from airbrakes.mock.mock_imu import MockIMU
+from airbrakes.utils import update_display
 from constants import (
     FREQUENCY,
     LOGS_PATH,
@@ -23,31 +25,13 @@ from constants import (
     UPSIDE_DOWN,
 )
 
-# ANSI escape code for cursor movement:
-MOVE_CURSOR_UP = "\033[F"  # Move the cursor one line up
-
-
-def update_display(airbrakes):
-    """Prints the values from the simulation in a pretty way."""
-    # Print values with multiple print statements
-    # The <10 is used to align the values to the left with a width of 10
-    # The .2f is used to format the float to 2 decimal places
-    print(f"State:                       {airbrakes.state.name:<10}")
-    print(f"Current speed:               {airbrakes.data_processor.speed:<10.2f} m/s")
-    print(f"Max speed so far:            {airbrakes.data_processor.max_speed:<10.2f} m/s")
-    print(f"Current altitude:            {airbrakes.data_processor.current_altitude:<10.2f} m")
-    print(f"Max altitude so far:         {airbrakes.data_processor.max_altitude:<10.2f} m")
-    print(f"Current airbrakes extension: {airbrakes.current_extension:<10}")
-
-    # Move the cursor up 6 lines to overwrite the previous output
-    print(MOVE_CURSOR_UP * 6, end="", flush=True)
-
 
 def main(is_simulation: bool) -> None:
     # Create the objects that will be used in the airbrakes context
     if is_simulation:
         imu = MockIMU(SIMULATION_LOG_PATH, FREQUENCY)
         servo = Servo(SERVO_PIN, MIN_EXTENSION, MAX_EXTENSION, pin_factory=MockFactory(pin_class=MockPWMPin))
+        sim_time_start = time.time()
         print(f"\n{'='*10} REAL TIME FLIGHT DATA {'='*10}\n")
     else:
         servo = Servo(SERVO_PIN, MIN_EXTENSION, MAX_EXTENSION)
@@ -66,7 +50,7 @@ def main(is_simulation: bool) -> None:
             airbrakes.update()
 
             if is_simulation:
-                update_display(airbrakes)
+                update_display(airbrakes, sim_time_start)
 
     except KeyboardInterrupt:
         pass

--- a/main.py
+++ b/main.py
@@ -30,6 +30,8 @@ MOVE_CURSOR_UP = "\033[F"  # Move the cursor one line up
 def update_display(airbrakes):
     """Prints the values from the simulation in a pretty way."""
     # Print values with multiple print statements
+    # The <10 is used to align the values to the left with a width of 10
+    # The .2f is used to format the float to 2 decimal places
     print(f"State:                       {airbrakes.state.name:<10}")
     print(f"Current speed:               {airbrakes.data_processor.speed:<10.2f} m/s")
     print(f"Max speed so far:            {airbrakes.data_processor.max_speed:<10.2f} m/s")

--- a/main.py
+++ b/main.py
@@ -19,16 +19,34 @@ from constants import (
     MOCK_ARGUMENT,
     PORT,
     SERVO_PIN,
-    SIMULATION_LOG_NAME,
+    SIMULATION_LOG_PATH,
     UPSIDE_DOWN,
 )
+
+# ANSI escape code for cursor movement:
+MOVE_CURSOR_UP = "\033[F"  # Move the cursor one line up
+
+
+def update_display(airbrakes):
+    """Prints the values from the simulation in a pretty way."""
+    # Print values with multiple print statements
+    print(f"State:                       {airbrakes.state.name:<10}")
+    print(f"Current speed:               {airbrakes.data_processor.speed:<10.2f} m/s")
+    print(f"Max speed so far:            {airbrakes.data_processor.max_speed:<10.2f} m/s")
+    print(f"Current altitude:            {airbrakes.data_processor.current_altitude:<10.2f} m")
+    print(f"Max altitude so far:         {airbrakes.data_processor.max_altitude:<10.2f} m")
+    print(f"Current airbrakes extension: {airbrakes.current_extension:<10}")
+
+    # Move the cursor up 6 lines to overwrite the previous output
+    print(MOVE_CURSOR_UP * 6, end="", flush=True)
 
 
 def main(is_simulation: bool) -> None:
     # Create the objects that will be used in the airbrakes context
     if is_simulation:
-        imu = MockIMU(SIMULATION_LOG_NAME, FREQUENCY)
+        imu = MockIMU(SIMULATION_LOG_PATH, FREQUENCY)
         servo = Servo(SERVO_PIN, MIN_EXTENSION, MAX_EXTENSION, pin_factory=MockFactory(pin_class=MockPWMPin))
+        print(f"\n{'='*10} REAL TIME FLIGHT DATA {'='*10}\n")
     else:
         servo = Servo(SERVO_PIN, MIN_EXTENSION, MAX_EXTENSION)
         imu = IMU(PORT, FREQUENCY)
@@ -44,6 +62,10 @@ def main(is_simulation: bool) -> None:
         # This is the main loop that will run until we press Ctrl+C
         while not airbrakes.shutdown_requested:
             airbrakes.update()
+
+            if is_simulation:
+                update_display(airbrakes)
+
     except KeyboardInterrupt:
         pass
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ select = ["E", "F", "I", "PL", "UP", "RUF", "PTH", "C4", "B", "PIE", "SIM", "RET
           "D100", "D101", "D300", "D418", "D419", "S"]
 
 [tool.ruff.lint.per-file-ignores]
+"main.py" = ["T201"]
 "tests/*.py" = ["T20", "S101", "D100", "ARG001", "RUF012"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ select = ["E", "F", "I", "PL", "UP", "RUF", "PTH", "C4", "B", "PIE", "SIM", "RET
 
 [tool.ruff.lint.per-file-ignores]
 "main.py" = ["T201"]
+"airbrakes/utils.py" = ["T201"]
 "tests/*.py" = ["T20", "S101", "D100", "ARG001", "RUF012"]
 
 


### PR DESCRIPTION
- Adds winter '23 launch data csv file
- `MockIMU` accepts a Path object to read the sim file
- Ignore Ctrl+C signal in MockIMU process
- Simulation values are now printed in the console and updated in real time. 
![image](https://github.com/user-attachments/assets/7875b3db-7f3d-4495-ae6d-3cdde354990d)

