### PR TITLE
Add log buffer 

### DIFF
--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -88,8 +88,9 @@ class AirbrakesContext:
         # data packet
         i = 0
         for data_packet in data_packets:
-            logged_data_packet = LoggedDataPacket(state=self.state.name[0], extension=self.current_extension,
-                                                  timestamp=data_packet.timestamp)
+            logged_data_packet = LoggedDataPacket(
+                state=self.state.name[0], extension=self.current_extension, timestamp=data_packet.timestamp
+            )
             logged_data_packet.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):
                 logged_data_packet.set_processed_data_packet_attributes(processed_data_packets[i])

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -1,16 +1,19 @@
 """Module which provides a high level interface to the air brakes system on the rocket."""
 
 import collections
+from typing import TYPE_CHECKING
 
 from airbrakes.data_handling.data_processor import IMUDataProcessor
-from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, RawDataPacket
+from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from airbrakes.data_handling.logger import Logger
-from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 from airbrakes.hardware.imu import IMU, IMUDataPacket
 from airbrakes.hardware.servo import Servo
 from airbrakes.state import StandByState, State
 from constants import ServoExtension
+
+if TYPE_CHECKING:
+    from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 
 
 class AirbrakesContext:

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -216,7 +216,7 @@ class IMUDataProcessor:
         if len(self._data_points) < 1:
             return np.array([0.0])
 
-        # Prevent subtle bug in at init, when we only process one data packet, and the 
+        # Prevent subtle bug in at init, when we only process one data packet, and the
         # last_data_point is a dummy set in __init__.
         if self._last_data_point.timestamp == 0.0:
             return np.array([0.0] * len(self._data_points))

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 from airbrakes.utils import deadband
-from constants import ACCLERATION_NOISE_THRESHOLD
+from constants import ACCELERATION_NOISE_THRESHOLD
 
 
 class IMUDataProcessor:
@@ -130,9 +130,9 @@ class IMUDataProcessor:
         # If the absolute value of acceleration is less than 0.1, set it to 0
         x_accel, y_accel, z_accel, pressure_altitudes = deque(), deque(), deque(), deque()
         for data_point in self._data_points:
-            x_accel.append(deadband(data_point.estLinearAccelX, ACCLERATION_NOISE_THRESHOLD))
-            y_accel.append(deadband(data_point.estLinearAccelY, ACCLERATION_NOISE_THRESHOLD))
-            z_accel.append(deadband(data_point.estLinearAccelZ, ACCLERATION_NOISE_THRESHOLD))
+            x_accel.append(deadband(data_point.estLinearAccelX, ACCELERATION_NOISE_THRESHOLD))
+            y_accel.append(deadband(data_point.estLinearAccelY, ACCELERATION_NOISE_THRESHOLD))
+            z_accel.append(deadband(data_point.estLinearAccelZ, ACCELERATION_NOISE_THRESHOLD))
             pressure_altitudes.append(data_point.estPressureAlt)
 
         a_x, a_y, a_z = self._compute_averages(x_accel, y_accel, z_accel)

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -2,19 +2,12 @@
 
 import collections
 import csv
-import inspect
 import multiprocessing
 import signal
 from pathlib import Path
 
-from airbrakes.data_handling.data_processor import IMUDataProcessor
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
-from constants import STOP_SIGNAL
-
-# Get public properties of IMUDataProcessor, which will be logged.
-_data_processor_properties = [
-    field_name for field_name, _ in inspect.getmembers(IMUDataProcessor, lambda o: isinstance(o, property))
-]
+from constants import LOG_BUFFER_SIZE, LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
 
 
 class Logger:
@@ -29,7 +22,7 @@ class Logger:
     :param log_dir: The directory where the log files will be.
     """
 
-    __slots__ = ("_log_process", "_log_queue", "log_path")
+    __slots__ = ("_log_process", "_log_queue", "log_path", "_log_counter", "_log_buffer")
 
     def __init__(self, log_dir: Path):
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -37,6 +30,10 @@ class Logger:
         # Get all existing log files and find the highest suffix number
         existing_logs = list(log_dir.glob("log_*.csv"))
         max_suffix = max(int(log.stem.split("_")[-1]) for log in existing_logs) if existing_logs else 0
+
+        # Buffer for StandbyState and LandedState
+        self._log_counter = 0
+        self._log_buffer = collections.deque(maxlen=LOG_BUFFER_SIZE)
 
         # Create a new log file with the next number in sequence
         self.log_path = log_dir / f"log_{max_suffix + 1}.csv"
@@ -83,6 +80,23 @@ class Logger:
         for logged_data_packet in logged_data_packets:
             # Formats the log message as a CSV line
             message_dict = {key: getattr(logged_data_packet, key) for key in logged_data_packet.__struct_fields__}
+
+            if logged_data_packet.state in ["S", "L"]:  # S: StandbyState, L: LandedState
+                if self._log_counter < LOG_CAPACITY_AT_STANDBY:
+                    # add the count:
+                    self._log_counter += 1
+                else:
+                    self._log_buffer.append(message_dict)
+                    continue
+            else:
+                if self._log_buffer:
+                    # Log the buffer before logging the new message
+                    for buffered_message in self._log_buffer:
+                        self._log_queue.put(buffered_message)
+                    self._log_buffer.clear()
+
+                self._log_counter = 0  # Reset the counter for other states
+
             # Put the message in the queue
             self._log_queue.put(message_dict)
 

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -22,7 +22,7 @@ class Logger:
     :param log_dir: The directory where the log files will be.
     """
 
-    __slots__ = ("_log_process", "_log_queue", "log_path", "_log_counter", "_log_buffer")
+    __slots__ = ("_log_buffer", "_log_counter", "_log_process", "_log_queue", "log_path")
 
     def __init__(self, log_dir: Path):
         log_dir.mkdir(parents=True, exist_ok=True)

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -132,7 +132,7 @@ class CoastState(State):
     we actually extend the airbrakes.
     """
 
-    __slots__ = ("start_time", "airbrakes_extended")
+    __slots__ = ("airbrakes_extended", "start_time")
 
     def __init__(self, context: "AirbrakesContext"):
         super().__init__(context)

--- a/constants.py
+++ b/constants.py
@@ -91,7 +91,7 @@ ACCELERATION_NOISE_THRESHOLD = 0.35   # m/s^2
 
 # We will take the magnitude of acceleration for this
 TAKEOFF_HEIGHT = 10  # meters
-TAKEOFF_SPEED = 2  # m/s  # TODO: Change this back!
+TAKEOFF_SPEED = 10  # m/s
 
 # MotorBurn to Coasting:
 # Acceleration inside this range will be considered as the motor burnout acceleration

--- a/constants.py
+++ b/constants.py
@@ -76,9 +76,9 @@ STOP_SIGNAL = "STOP"
 DATA_PACKET_DECIMAL_PLACES = 8
 
 # Don't log more than x packets for StandbyState and LandedState
-LOG_CAPACITY_AT_STANDBY = 15000
+LOG_CAPACITY_AT_STANDBY = 5000
 # Buffer size if CAPACITY is reached. Once the state changes, this buffer will be logged to make sure we don't lose data
-LOG_BUFFER_SIZE = 1000
+LOG_BUFFER_SIZE = 5000
 
 # -------------------------------------------------------
 # State Machine Configuration
@@ -87,7 +87,7 @@ LOG_BUFFER_SIZE = 1000
 # Arbitrarily set values for transition between states:
 
 # Standby to MotorBurn:
-ACCLERATION_NOISE_THRESHOLD = 0.3  # m/s^2
+ACCELERATION_NOISE_THRESHOLD = 0.35   # m/s^2
 
 # We will take the magnitude of acceleration for this
 TAKEOFF_HEIGHT = 10  # meters

--- a/constants.py
+++ b/constants.py
@@ -71,6 +71,11 @@ STOP_SIGNAL = "STOP"
 
 DATA_PACKET_DECIMAL_PLACES = 8
 
+# Don't log more than x packets for StandbyState and LandedState
+LOG_CAPACITY_AT_STANDBY = 15000
+# Buffer size if CAPACITY is reached. Once the state changes, this buffer will be logged to make sure we don't lose data
+LOG_BUFFER_SIZE = 1000
+
 # -------------------------------------------------------
 # State Machine Configuration
 # -------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -58,5 +58,4 @@ def main(is_simulation: bool, real_servo: bool) -> None:
 
 if __name__ == "__main__":
     # If the mock argument is passed in, then run the simulation: python main.py mock
-    main(len(sys.argv) > 1 and MOCK_ARGUMENT in sys.argv[1:],
-         len(sys.argv) > 1 and REAL_SERVO_ARGUMENT in sys.argv[1:])
+    main(len(sys.argv) > 1 and MOCK_ARGUMENT in sys.argv[1:], len(sys.argv) > 1 and REAL_SERVO_ARGUMENT in sys.argv[1:])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -9,12 +9,8 @@ import pytest
 from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, RawDataPacket
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from airbrakes.data_handling.logger import Logger
-<<<<<<< HEAD
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 from constants import LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
-=======
-from constants import STOP_SIGNAL
->>>>>>> log-shortening
 from tests.conftest import LOG_PATH
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -108,6 +108,7 @@ class TestStandByState:
         stand_by_state.update()
         assert isinstance(stand_by_state.context.state, expected_state)
 
+
 class TestMotorBurnState:
     """Tests the MotorBurnState class"""
 


### PR DESCRIPTION
- Logs 15000 packets max when in StandbyState and LandedState
- Buffer is also implemented when the state changes from StandbyState to MotorBurnState, so we don't lose any logs (buffer is of a 1000 packets, and the pi on average processes about 25 packets.)


Can be merged to #26 