### PR TITLE
fixed element order of quaternion vectors

### DIFF
--- a/airbrakes/data_handling/imu_data_packet.py
+++ b/airbrakes/data_handling/imu_data_packet.py
@@ -35,15 +35,15 @@ class EstimatedDataPacket(IMUDataPacket):
     estimated values of the relevant data points.
     """
 
+    estOrientQuaternionW: float | None = None
     estOrientQuaternionX: float | None = None
     estOrientQuaternionY: float | None = None
     estOrientQuaternionZ: float | None = None
-    estOrientQuaternionW: float | None = None
     estPressureAlt: float | None = None
+    estAttitudeUncertQuaternionW: float | None = None
     estAttitudeUncertQuaternionX: float | None = None
     estAttitudeUncertQuaternionY: float | None = None
     estAttitudeUncertQuaternionZ: float | None = None
-    estAttitudeUncertQuaternionW: float | None = None
     estAngularRateX: float | None = None
     estAngularRateY: float | None = None
     estAngularRateZ: float | None = None

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -27,15 +27,15 @@ class LoggedDataPacket(msgspec.Struct):
     scaledGyroZ: float | None = None
 
     # Estimated Data Packet Fields
+    estOrientQuaternionW: float | None = None
     estOrientQuaternionX: float | None = None
     estOrientQuaternionY: float | None = None
     estOrientQuaternionZ: float | None = None
-    estOrientQuaternionW: float | None = None
     estPressureAlt: float | None = None
+    estAttitudeUncertQuaternionW: float | None = None
     estAttitudeUncertQuaternionX: float | None = None
     estAttitudeUncertQuaternionY: float | None = None
     estAttitudeUncertQuaternionZ: float | None = None
-    estAttitudeUncertQuaternionW: float | None = None
     estAngularRateX: float | None = None
     estAngularRateY: float | None = None
     estAngularRateZ: float | None = None

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -154,9 +154,9 @@ class IMU:
                             match channel:
                                 # These specific data points are matrix's rather than doubles
                                 case "estAttitudeUncertQuaternion" | "estOrientQuaternion":
-                                    # This makes a 4x1 matrix from the data point with the data as [[x], [y], [z], [w]]
+                                    # This makes a 4x1 matrix from the data point with the data as [[w], [x], [y], [z]]
                                     matrix = data_point.as_Matrix()
-                                    # Sets the X, Y, Z, and W of the quaternion to the data packet object
+                                    # Sets the W, X, Y, and Z of the quaternion to the data packet object
                                     setattr(imu_data_packet, f"{channel}X", matrix.as_floatAt(0, 0))
                                     setattr(imu_data_packet, f"{channel}Y", matrix.as_floatAt(0, 1))
                                     setattr(imu_data_packet, f"{channel}Z", matrix.as_floatAt(0, 2))

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -157,10 +157,10 @@ class IMU:
                                     # This makes a 4x1 matrix from the data point with the data as [[w], [x], [y], [z]]
                                     matrix = data_point.as_Matrix()
                                     # Sets the W, X, Y, and Z of the quaternion to the data packet object
-                                    setattr(imu_data_packet, f"{channel}X", matrix.as_floatAt(0, 0))
-                                    setattr(imu_data_packet, f"{channel}Y", matrix.as_floatAt(0, 1))
-                                    setattr(imu_data_packet, f"{channel}Z", matrix.as_floatAt(0, 2))
-                                    setattr(imu_data_packet, f"{channel}W", matrix.as_floatAt(0, 3))
+                                    setattr(imu_data_packet, f"{channel}W", matrix.as_floatAt(0, 0))
+                                    setattr(imu_data_packet, f"{channel}X", matrix.as_floatAt(0, 1))
+                                    setattr(imu_data_packet, f"{channel}Y", matrix.as_floatAt(0, 2))
+                                    setattr(imu_data_packet, f"{channel}Z", matrix.as_floatAt(0, 3))
                                 case _:
                                     # Because the attribute names in our data packet classes are the same as the channel
                                     # names, we can just set the attribute to the value of the data point.

--- a/tests/test_imu_data_packet.py
+++ b/tests/test_imu_data_packet.py
@@ -14,10 +14,10 @@ class TestEstimatedDataPacket:
             estOrientQuaternionZ=0.3,
             estOrientQuaternionW=0.4,
             estPressureAlt=1013.25,
+            estAttitudeUncertQuaternionW=0.04,
             estAttitudeUncertQuaternionX=0.01,
             estAttitudeUncertQuaternionY=0.02,
             estAttitudeUncertQuaternionZ=0.03,
-            estAttitudeUncertQuaternionW=0.04,
             estAngularRateX=0.5,
             estAngularRateY=0.6,
             estAngularRateZ=0.7,
@@ -30,15 +30,15 @@ class TestEstimatedDataPacket:
         )
 
         assert packet.timestamp == 123456789
+        assert packet.estOrientQuaternionW == 0.4
         assert packet.estOrientQuaternionX == 0.1
         assert packet.estOrientQuaternionY == 0.2
         assert packet.estOrientQuaternionZ == 0.3
-        assert packet.estOrientQuaternionW == 0.4
         assert packet.estPressureAlt == 1013.25
+        assert packet.estAttitudeUncertQuaternionW == 0.04
         assert packet.estAttitudeUncertQuaternionX == 0.01
         assert packet.estAttitudeUncertQuaternionY == 0.02
         assert packet.estAttitudeUncertQuaternionZ == 0.03
-        assert packet.estAttitudeUncertQuaternionW == 0.04
         assert packet.estAngularRateX == 0.5
         assert packet.estAngularRateY == 0.6
         assert packet.estAngularRateZ == 0.7
@@ -53,15 +53,15 @@ class TestEstimatedDataPacket:
         packet = EstimatedDataPacket(timestamp=123456789)
 
         assert packet.timestamp == 123456789
+        assert packet.estOrientQuaternionW is None
         assert packet.estOrientQuaternionX is None
         assert packet.estOrientQuaternionY is None
         assert packet.estOrientQuaternionZ is None
-        assert packet.estOrientQuaternionW is None
         assert packet.estPressureAlt is None
+        assert packet.estAttitudeUncertQuaternionW is None
         assert packet.estAttitudeUncertQuaternionX is None
         assert packet.estAttitudeUncertQuaternionY is None
         assert packet.estAttitudeUncertQuaternionZ is None
-        assert packet.estAttitudeUncertQuaternionW is None
         assert packet.estAngularRateX is None
         assert packet.estAngularRateY is None
         assert packet.estAngularRateZ is None


### PR DESCRIPTION
Changed quaternions so they are logged as [w x y z], we had it as [x y z w], which is out of order.