### PR TITLE
Log and use invalid data packets

### DIFF
--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -92,9 +92,7 @@ class AirbrakesContext:
         i = 0
         for data_packet in data_packets:
             logged_data_packet = LoggedDataPacket(
-                state=self.state.name[0],
-                extension=self.current_extension.value,
-                timestamp=data_packet.timestamp
+                state=self.state.name[0], extension=self.current_extension.value, timestamp=data_packet.timestamp
             )
             logged_data_packet.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -92,7 +92,8 @@ class AirbrakesContext:
         i = 0
         for data_packet in data_packets:
             logged_data_packet = LoggedDataPacket(
-                state=self.state.name[0], extension=self.current_extension.value, timestamp=data_packet.timestamp
+                state=self.state.name[0],
+                extension=self.current_extension.value,
             )
             logged_data_packet.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -94,6 +94,7 @@ class AirbrakesContext:
             logged_data_packet = LoggedDataPacket(
                 state=self.state.name[0],
                 extension=self.current_extension.value,
+                timestamp=data_packet.timestamp
             )
             logged_data_packet.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):

--- a/airbrakes/data_handling/imu_data_packet.py
+++ b/airbrakes/data_handling/imu_data_packet.py
@@ -11,6 +11,8 @@ class IMUDataPacket(msgspec.Struct):
     """
 
     timestamp: int  # in nanoseconds
+    # list of fields which may be invalid as reported by the IMU
+    invalid_fields: list[str] | None = None
 
 
 class RawDataPacket(IMUDataPacket):

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -16,7 +16,10 @@ class LoggedDataPacket(msgspec.Struct):
 
     state: str
     extension: float
+
+    # IMU Data Packet Fields
     timestamp: float
+    invalid_fields: list[str] | None = None
 
     # Raw Data Packet Fields
     scaledAccelX: float | None = None
@@ -54,7 +57,8 @@ class LoggedDataPacket(msgspec.Struct):
 
     def set_imu_data_packet_attributes(self, imu_data_packet: IMUDataPacket) -> None:
         """
-        Sets the attributes of the data packet corresponding to the IMU data packet.
+        Sets the attributes of the data packet corresponding to the IMU data packet. Performs
+        some processing to round the float values to 8 decimal places.
         """
         for key in imu_data_packet.__struct_fields__:
             if hasattr(self, key):

--- a/scripts/data_visualizer.py
+++ b/scripts/data_visualizer.py
@@ -3,16 +3,16 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from pathlib import Path
 
-imu_data = pd.read_csv(Path('logs/log_16.csv'))
+imu_data = pd.read_csv(Path('scripts/imu_data/InterestLaunch-9-28 (No Airbrakes Deployed).csv'))
 # Filtering relevant columns for computation
-fields = ['timestamp', "speed", 'estPressureAlt']
+fields = ['timestamp', "speed", 'current_altitude', "estLinearAccelX", "estLinearAccelY", "estLinearAccelZ",]
 imu_data_filtered = imu_data[fields].dropna()
 
 # Convert timestamps from nanoseconds to seconds
 # Zeroing the time axis by subtracting the initial timestamp
-# imu_data_filtered['timestamp_sec'] = imu_data_filtered['time'] * 1e-9
-# imu_data_filtered['timestamp_sec'] = imu_data_filtered['timestamp_sec'] - imu_data_filtered['timestamp_sec'].iloc[0]
-# print(max(imu_data_filtered["timestamp_sec"]))
+imu_data_filtered['timestamp_sec'] = imu_data_filtered['timestamp'] * 1e-9
+imu_data_filtered['timestamp_sec'] = imu_data_filtered['timestamp_sec'] - imu_data_filtered['timestamp_sec'].iloc[0]
+print(max(imu_data_filtered["timestamp_sec"]))
 
 # error case: in one of our runs, the timestamp produced by the IMU was greater than 5 seconds, 
 # sometimes going up to 1750 seconds.
@@ -25,11 +25,11 @@ imu_data_filtered = imu_data[fields].dropna()
 
 
 # Compute velocity by differentiating estPressureAlt with respect to time
-time_diff = np.diff(imu_data_filtered['timestamp'])
-# position_diff = np.diff(imu_data_filtered['estPressureAlt'])
+time_diff = np.diff(imu_data_filtered['timestamp_sec'])
+position_diff = np.diff(imu_data_filtered['current_altitude'])
 
 # Velocity from pressure altitude differentiation
-# velocity_from_alt = position_diff / time_diff
+velocity_from_alt = position_diff / time_diff
 
 # Get acceleration magnitude
 # acceleration_magnitude = np.sqrt(imu_data_filtered['estLinearAccelX']**2 + imu_data_filtered['estLinearAccelY']**2 + imu_data_filtered['estLinearAccelZ']**2)
@@ -45,7 +45,7 @@ print(velocity_from_accel_component)
 
 
 # Plotting the results
-# plt.figure(figsize=(12, 6))
+plt.figure(figsize=(12, 6))
 # plt.subplot(3, 1, 1)
 # plt.plot(imu_data_filtered["time"], acceleration_magnitude, label='Acceleration Magnitude')
 # plt.title('Acceleration Magnitude')
@@ -53,36 +53,33 @@ print(velocity_from_accel_component)
 # plt.ylabel('Linear accel Mag (m/s^2)')
 # plt.grid(True)
 
+# Plot velocity from estPressureAlt differentiation
+plt.subplot(3, 1, 1)
+plt.plot(imu_data_filtered['timestamp_sec'][:-1], velocity_from_alt, label='Velocity from estPressureAlt')
+plt.xlabel('Time (seconds)')
+plt.ylabel('Velocity (m/s)')
+plt.title('Velocity from estPressureAlt (Differentiation)')
+plt.xlim(left=1800)
+plt.grid(True)
+
+# # Plot velocity from acceleration integration
 plt.subplot(3, 1, 2)
-plt.plot(imu_data_filtered['timestamp'][:-1], velocity_from_accel_component, label='Speed from estLinearAccel', color='r')
+plt.plot(imu_data_filtered['timestamp_sec'][:-1], velocity_from_accel_component, label='Speed from estLinearAccel', color='r')
 plt.xlabel('Time (seconds)')
 plt.ylabel('Velocity (m/s)')
 plt.title('Speed from Linear Accel')
+# plt.xlim(left=1800)
 plt.grid(True)
 
 # plot altitude
 plt.subplot(3, 1, 3)
-plt.plot(imu_data_filtered['timestamp'], imu_data_filtered['estimated_altitude'], label='Estimated Altitude')
+plt.plot(imu_data_filtered['timestamp_sec'], imu_data_filtered['current_altitude'], label='Estimated Altitude')
 plt.xlabel('Time (seconds)')
 plt.ylabel('Altitude (m)')
 plt.title('Pressure Altitude')
+plt.xlim(left=1800)
 plt.grid(True)
 
-# Plot velocity from estPressureAlt differentiation
-# plt.subplot(2, 1, 1)
-# plt.plot(imu_data_filtered['timestamp_sec'][:-1], velocity_from_alt, label='Velocity from estPressureAlt')
-# plt.xlabel('Time (seconds)')
-# plt.ylabel('Velocity (m/s)')
-# plt.title('Velocity from estPressureAlt (Differentiation)')
-# plt.grid(True)
-
-# # Plot velocity from acceleration integration
-# plt.subplot(2, 1, 2)
-# plt.plot(imu_data_filtered['timestamp_sec'][:-1], velocity_from_accel_component, label='Velocity from estLinearAccel', color='r')
-# plt.xlabel('Time (seconds)')
-# plt.ylabel('Velocity (m/s)')
-# plt.title('Velocity from Linear Acceleration (Integration)')
-# plt.grid(True)
 
 plt.tight_layout()
-plt.savefig("scripts/plots/previous_flight_accel_data.png")
+plt.savefig("scripts/plots/interest_launch_data.png")

--- a/tests/test_imu.py
+++ b/tests/test_imu.py
@@ -169,3 +169,8 @@ class TestIMU:
 
         # Practically the ratio may not be exactly 1:2
         assert raw_count / est_count >= 1.70, f"Actual ratio was: {raw_count / est_count}"
+
+    @pytest.mark.skip(reason="Need to install mscl in the CI and ideally auto-build locally.")
+    def test_imu_data_loop(self):
+        # Mock the MSCL library and related methods/classes to test the IMU data loop completely:
+        pass

--- a/tests/test_imu_data_packet.py
+++ b/tests/test_imu_data_packet.py
@@ -27,9 +27,11 @@ class TestEstimatedDataPacket:
             estLinearAccelX=0.0,
             estLinearAccelY=0.0,
             estLinearAccelZ=0.0,
+            invalid_fields=["estOrientQuaternion"],
         )
 
         assert packet.timestamp == 123456789
+        assert packet.invalid_fields == ["estOrientQuaternion"]
         assert packet.estOrientQuaternionW == 0.4
         assert packet.estOrientQuaternionX == 0.1
         assert packet.estOrientQuaternionY == 0.2
@@ -53,6 +55,7 @@ class TestEstimatedDataPacket:
         packet = EstimatedDataPacket(timestamp=123456789)
 
         assert packet.timestamp == 123456789
+        assert packet.invalid_fields is None
         assert packet.estOrientQuaternionW is None
         assert packet.estOrientQuaternionX is None
         assert packet.estOrientQuaternionY is None
@@ -86,6 +89,7 @@ class TestRawDataPacket:
     def test_raw_data_packet_initialization(self):
         packet = RawDataPacket(
             timestamp=123456789,
+            invalid_fields=["scaledAccelX"],
             scaledAccelX=1.0,
             scaledAccelY=2.0,
             scaledAccelZ=3.0,
@@ -95,6 +99,7 @@ class TestRawDataPacket:
         )
 
         assert packet.timestamp == 123456789
+        assert packet.invalid_fields == ["scaledAccelX"]
         assert packet.scaledAccelX == 1.0
         assert packet.scaledAccelY == 2.0
         assert packet.scaledAccelZ == 3.0
@@ -106,6 +111,7 @@ class TestRawDataPacket:
         packet = RawDataPacket(timestamp=123456789)
 
         assert packet.timestamp == 123456789
+        assert packet.invalid_fields is None
         assert packet.scaledAccelX is None
         assert packet.scaledAccelY is None
         assert packet.scaledAccelZ is None

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -60,9 +60,9 @@ class TestLogger:
 
     def test_init_log_file_has_correct_headers(self, logger):
         with logger.log_path.open() as f:
-            reader = csv.reader(f)
-            headers = next(reader)  # Gets the first row, which are the headers
-            assert tuple(headers) == LoggedDataPacket.__struct_fields__
+            reader = csv.DictReader(f)
+            keys = reader.fieldnames
+            assert tuple(keys) == LoggedDataPacket.__struct_fields__
 
     def test_logging_loop_start_stop(self, logger):
         logger.start()
@@ -100,11 +100,11 @@ class TestLogger:
         assert values.qsize() == 1
         assert values.get() == "clean exit"
 
-    def test_logger_context_manager_with_exception(self, monkeypatch):
-        """Tests whether the Logger context manager propogates unknown exceptions."""
+    def test_logger_loop_exception_raised(self, monkeypatch):
+        """Tests whether the Logger loop properly propogates unknown exceptions."""
         values = multiprocessing.Queue()
 
-        def _logging_loop(self):
+        def _logging_loop(_):
             """Monkeypatched method for testing."""
             signal.signal(signal.SIGINT, signal.SIG_IGN)
             while True:
@@ -126,22 +126,21 @@ class TestLogger:
         assert "some error" in str(excinfo.value)
 
     def test_logging_loop_add_to_queue(self, logger):
-        test_log = {"state": "state", "extension": "0.0", "timestamp": "4"}
+        test_log = {"state": "state", "extension": "0.0", "timestamp": "4", "invalid_fields": "[]"}
         logger._log_queue.put(test_log)
         assert logger._log_queue.qsize() == 1
         logger.start()
-        time.sleep(0.05)  # Give the process time to log to file
+        time.sleep(0.01)  # Give the process time to log to file
         logger.stop()
         # Let's check the contents of the file:
         with logger.log_path.open() as f:
-            reader = csv.reader(f)
-            headers = next(reader)
+            reader = csv.DictReader(f)
+            headers = reader.fieldnames
             assert tuple(headers) == LoggedDataPacket.__struct_fields__
-            row: list[str] = next(reader)
-            # create dictionary from headers (field names) and row (values)
-            row_dict = dict(zip(LoggedDataPacket.__struct_fields__, row, strict=False))
-            # Only fetch non-empty values:
-            row_dict = {k: v for k, v in row_dict.items() if v}
+            for row in reader:
+                row: dict[str]
+                # Only fetch non-empty values:
+                row_dict = {k: v for k, v in row.items() if v}
 
             assert row_dict == test_log
 
@@ -150,7 +149,9 @@ class TestLogger:
     @pytest.mark.parametrize(
         "data_packet",
         [
-            LoggedDataPacket(*("1" for _ in range(len(LoggedDataPacket.__struct_fields__)))),
+            LoggedDataPacket(
+                **{k: "1" for k in LoggedDataPacket.__struct_fields__},
+            ),
         ],
         ids=[
             "RawDataPacket",
@@ -159,25 +160,30 @@ class TestLogger:
     def test_log_method(self, logger, data_packet):
         """Tests whether the log method logs the data correctly to the CSV file."""
         logger.start()
+
+        # make `invalid_fields` a list for accurate comparison:
+        data_packet.invalid_fields = ["something_invalid"]
+
         logger.log([data_packet])
         time.sleep(0.01)  # Give the process time to log to file
         logger.stop()
+
         # Let's check the contents of the file:
         with logger.log_path.open() as f:
-            reader = csv.reader(f)
-            headers = next(reader)
+            reader = csv.DictReader(f)
+            headers = reader.fieldnames
             assert tuple(headers) == LoggedDataPacket.__struct_fields__
 
             # The row with the data packet:
-            row: list[str] = next(reader)
-            # create dictionary from headers (field names) and row (values)
-            row_dict = dict(zip(LoggedDataPacket.__struct_fields__, row, strict=False))
-            # Only fetch non-empty values:
-            row_dict = {k: v for k, v in row_dict.items() if v}
+            for row in reader:
+                row: dict[str]
+                # Only fetch non-empty values:
+                row_dict = {k: v for k, v in row.items() if v}
 
             processed_data_packet_fields = list(ProcessedDataPacket.__struct_fields__)
             processed_data_packet_fields.remove("estimated_data_packet")
 
+            assert len(row_dict) > 10  # Random check to make sure we aren't missing any fields
             assert row_dict == {
                 "state": "1",
                 "extension": "1",


### PR DESCRIPTION
As discussed by @wlsanderson and I, the interest launch did not log all quaternions since they were marked "invalid" by the IMU - Why?

Due to high rotation rates during coast and free fall, the IMU cannot reliably process data even though it was well within the specifications of the IMU, and there are no threshold settings we can change with regards to this. 

Thus, we decided to log invalid data packets as well. This can be used in the apogee prediction, which would have used the noisy/inaccurate data anyway, but using the quaternions directly saves us some computation.

PR changes:

- All attributes of a data packet are set, whether it is valid or not.
- Adds the `invalid_fields` parameter to identify which fields of the data packet were invalid
