### PR TITLE
Performance Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ flowchart TD
     %%IMUDataProcessor --> ProcessedData[(Processed Data Packet)]:::outputSquare
     IMUDataProcessor --> Speed[(Speed)]:::outputSquare
     IMUDataProcessor --> Altitude[(Altitude)]:::outputSquare
-    IMUDataProcessor --> AvgAccel[(Avg Acceleration)]:::outputSquare
     
     Speed -->  ProcessedData[(Processed Data Packet)]:::outputSquare
     Altitude -->  ProcessedData[(Processed Data Packet)]:::outputSquare
-    AvgAccel -->  ProcessedData[(Processed Data Packet)]:::outputSquare
     
      ProcessedData[(Processed Data Packet)]:::outputSquare --> Update
 

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -91,15 +91,15 @@ class AirbrakesContext:
         # data packet
         i = 0
         for data_packet in data_packets:
-            logged_data_packet = LoggedDataPacket(
+            ldp = LoggedDataPacket(
                 state=self.state.name[0], extension=self.current_extension.value, timestamp=data_packet.timestamp
             )
-            logged_data_packet.set_imu_data_packet_attributes(data_packet)
+            ldp.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):
-                logged_data_packet.set_processed_data_packet_attributes(processed_data_packets[i])
+                ldp.set_processed_data_packet_attributes(processed_data_packets[i])
                 i += 1
 
-            logged_data_packets.append(logged_data_packet)
+            logged_data_packets.append(ldp)
         # Logs the current state, extension, IMU data, and processed data
         self.logger.log(logged_data_packets)
 

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -91,15 +91,15 @@ class AirbrakesContext:
         # data packet
         i = 0
         for data_packet in data_packets:
-            ldp = LoggedDataPacket(
+            logged_data_packet = LoggedDataPacket(
                 state=self.state.name[0], extension=self.current_extension.value, timestamp=data_packet.timestamp
             )
-            ldp.set_imu_data_packet_attributes(data_packet)
+            logged_data_packet.set_imu_data_packet_attributes(data_packet)
             if isinstance(data_packet, EstimatedDataPacket):
-                ldp.set_processed_data_packet_attributes(processed_data_packets[i])
+                logged_data_packet.set_processed_data_packet_attributes(processed_data_packets[i])
                 i += 1
 
-            logged_data_packets.append(ldp)
+            logged_data_packets.append(logged_data_packet)
         # Logs the current state, extension, IMU data, and processed data
         self.logger.log(logged_data_packets)
 

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -22,8 +22,6 @@ class IMUDataProcessor:
     """
 
     __slots__ = (
-        "_avg_accel",
-        "_avg_accel_mag",
         "_current_altitudes",
         "_data_points",
         "_initial_altitude",
@@ -36,8 +34,6 @@ class IMUDataProcessor:
     )
 
     def __init__(self, data_points: Sequence[EstimatedDataPacket], upside_down: bool = False):
-        self._avg_accel: tuple[float, float, float] = (0.0, 0.0, 0.0)
-        self._avg_accel_mag: float = 0.0
         self._max_altitude: float = 0.0
         self._speeds: list[float] = [0.0]
         self._max_speed: float = 0.0
@@ -57,34 +53,11 @@ class IMUDataProcessor:
     def __str__(self) -> str:
         return (
             f"{self.__class__.__name__}("
-            f"avg_acceleration={self.avg_acceleration}, "
-            f"avg_acceleration_mag={self.avg_acceleration_mag}, "
             f"max_altitude={self.max_altitude}, "
             f"current_altitude={self.current_altitude}, "
             f"speed={self.speed}, "
             f"max_speed={self.max_speed})"
         )
-
-    @property
-    def avg_acceleration_z(self) -> float:
-        """
-        Returns the average acceleration in the z direction of the data points, in m/s^2.
-        """
-        return self._avg_accel[-1]
-
-    @property
-    def avg_acceleration(self) -> tuple[float, float, float]:
-        """
-        Returns the averaged acceleration as a vector of the data points, in m/s^2.
-        """
-        return tuple(self._avg_accel)
-
-    @property
-    def avg_acceleration_mag(self) -> float:
-        """
-        Returns the magnitude of the acceleration vector of the data points, in m/s^2.
-        """
-        return self._avg_accel_mag
 
     @property
     def max_altitude(self) -> float:
@@ -135,10 +108,6 @@ class IMUDataProcessor:
             z_accel.append(deadband(data_point.estLinearAccelZ, ACCELERATION_NOISE_THRESHOLD))
             pressure_altitudes.append(data_point.estPressureAlt)
 
-        a_x, a_y, a_z = self._compute_averages(x_accel, y_accel, z_accel)
-        self._avg_accel = (a_x, a_y, a_z)
-        self._avg_accel_mag = (a_x**2 + a_y**2 + a_z**2) ** 0.5
-
         self._speeds: np.array[np.float64] = self._calculate_speeds(x_accel, y_accel, z_accel)
         self._max_speed = max(self._speeds.max(), self._max_speed)
 
@@ -164,7 +133,6 @@ class IMUDataProcessor:
         # makes a ProcessedDataPacket for EstimatedDataPacket
         return [
             ProcessedDataPacket(
-                avg_acceleration=self.avg_acceleration,
                 current_altitude=current_alt,
                 speed=speed,
             )
@@ -190,19 +158,6 @@ class IMUDataProcessor:
         # There is a decent chance that the zeroed out altitude is negative, e.g. if the rocket
         # landed at a height below from where it launched from, but that doesn't concern us.
         return np.array(alt_list) - self._initial_altitude
-
-    def _compute_averages(self, a_x: list[float], a_y: list[float], a_z: list[float]) -> tuple[float, float, float]:
-        """
-        Calculates the average acceleration and acceleration magnitude of the data points.
-
-        :param a_x: A list of the accelerations in the x direction.
-        :param a_y: A list of the accelerations in the y direction.
-        :param a_z: A list of the accelerations in the z direction.
-
-        :return: A numpy array of the average acceleration in the x, y, and z directions.
-        """
-        # calculate the average acceleration in the x, y, and z directions
-        return float(np.mean(a_x)), float(np.mean(a_y)), float(np.mean(a_z))
 
     def _calculate_speeds(self, a_x: list[float], a_y: list[float], a_z: list[float]) -> npt.NDArray[np.float64]:
         """

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -72,83 +72,82 @@ class LoggedDataPacket(msgspec.Struct):
 
         :param imu_data_packet: The IMU data packet to set the attributes from.
         """
-        idp = imu_data_packet
-        if isinstance(idp, EstimatedDataPacket):
+        if isinstance(imu_data_packet, EstimatedDataPacket):
             # super ugly code, but it results in a 10-14% speedup overall
             # The speed improvements come from not looping through the fields of the data packet
             # and using getattr() and setattr() to set the attributes of the logged data packet.
             # Additionally, rounding using f-strings is faster than round() by about ~25%
-            if idp.estOrientQuaternionW is not None:
-                self.estOrientQuaternionW = f"{idp.estOrientQuaternionW:.8f}"
-            if idp.estOrientQuaternionX is not None:
-                self.estOrientQuaternionX = f"{idp.estOrientQuaternionX:.8f}"
-            if idp.estOrientQuaternionY is not None:
-                self.estOrientQuaternionY = f"{idp.estOrientQuaternionY:.8f}"
-            if idp.estOrientQuaternionZ is not None:
-                self.estOrientQuaternionZ = f"{idp.estOrientQuaternionZ:.8f}"
-            if idp.estAttitudeUncertQuaternionW is not None:
-                self.estAttitudeUncertQuaternionW = f"{idp.estAttitudeUncertQuaternionW:.8f}"
-            if idp.estAttitudeUncertQuaternionX is not None:
-                self.estAttitudeUncertQuaternionX = f"{idp.estAttitudeUncertQuaternionX:.8f}"
-            if idp.estAttitudeUncertQuaternionY is not None:
-                self.estAttitudeUncertQuaternionY = f"{idp.estAttitudeUncertQuaternionY:.8f}"
-            if idp.estAttitudeUncertQuaternionZ is not None:
-                self.estAttitudeUncertQuaternionZ = f"{idp.estAttitudeUncertQuaternionZ:.8f}"
-            if idp.estAngularRateX is not None:
-                self.estAngularRateX = f"{idp.estAngularRateX:.8f}"
-            if idp.estAngularRateY is not None:
-                self.estAngularRateY = f"{idp.estAngularRateY:.8f}"
-            if idp.estAngularRateZ is not None:
-                self.estAngularRateZ = f"{idp.estAngularRateZ:.8f}"
-            if idp.estCompensatedAccelX is not None:
-                self.estCompensatedAccelX = f"{idp.estCompensatedAccelX:.8f}"
-            if idp.estCompensatedAccelY is not None:
-                self.estCompensatedAccelY = f"{idp.estCompensatedAccelY:.8f}"
-            if idp.estCompensatedAccelZ is not None:
-                self.estCompensatedAccelZ = f"{idp.estCompensatedAccelZ:.8f}"
-            if idp.estLinearAccelX is not None:
-                self.estLinearAccelX = f"{idp.estLinearAccelX:.8f}"
-            if idp.estLinearAccelY is not None:
-                self.estLinearAccelY = f"{idp.estLinearAccelY:.8f}"
-            if idp.estLinearAccelZ is not None:
-                self.estLinearAccelZ = f"{idp.estLinearAccelZ:.8f}"
-            if idp.estGravityVectorX is not None:
-                self.estGravityVectorX = f"{idp.estGravityVectorX:.8f}"
-            if idp.estGravityVectorY is not None:
-                self.estGravityVectorY = f"{idp.estGravityVectorY:.8f}"
-            if idp.estGravityVectorZ is not None:
-                self.estGravityVectorZ = f"{idp.estGravityVectorZ:.8f}"
-            if idp.estPressureAlt is not None:
-                self.estPressureAlt = f"{idp.estPressureAlt:.8f}"
+            if imu_data_packet.estOrientQuaternionW is not None:
+                self.estOrientQuaternionW = f"{imu_data_packet.estOrientQuaternionW:.8f}"
+            if imu_data_packet.estOrientQuaternionX is not None:
+                self.estOrientQuaternionX = f"{imu_data_packet.estOrientQuaternionX:.8f}"
+            if imu_data_packet.estOrientQuaternionY is not None:
+                self.estOrientQuaternionY = f"{imu_data_packet.estOrientQuaternionY:.8f}"
+            if imu_data_packet.estOrientQuaternionZ is not None:
+                self.estOrientQuaternionZ = f"{imu_data_packet.estOrientQuaternionZ:.8f}"
+            if imu_data_packet.estAttitudeUncertQuaternionW is not None:
+                self.estAttitudeUncertQuaternionW = f"{imu_data_packet.estAttitudeUncertQuaternionW:.8f}"
+            if imu_data_packet.estAttitudeUncertQuaternionX is not None:
+                self.estAttitudeUncertQuaternionX = f"{imu_data_packet.estAttitudeUncertQuaternionX:.8f}"
+            if imu_data_packet.estAttitudeUncertQuaternionY is not None:
+                self.estAttitudeUncertQuaternionY = f"{imu_data_packet.estAttitudeUncertQuaternionY:.8f}"
+            if imu_data_packet.estAttitudeUncertQuaternionZ is not None:
+                self.estAttitudeUncertQuaternionZ = f"{imu_data_packet.estAttitudeUncertQuaternionZ:.8f}"
+            if imu_data_packet.estAngularRateX is not None:
+                self.estAngularRateX = f"{imu_data_packet.estAngularRateX:.8f}"
+            if imu_data_packet.estAngularRateY is not None:
+                self.estAngularRateY = f"{imu_data_packet.estAngularRateY:.8f}"
+            if imu_data_packet.estAngularRateZ is not None:
+                self.estAngularRateZ = f"{imu_data_packet.estAngularRateZ:.8f}"
+            if imu_data_packet.estCompensatedAccelX is not None:
+                self.estCompensatedAccelX = f"{imu_data_packet.estCompensatedAccelX:.8f}"
+            if imu_data_packet.estCompensatedAccelY is not None:
+                self.estCompensatedAccelY = f"{imu_data_packet.estCompensatedAccelY:.8f}"
+            if imu_data_packet.estCompensatedAccelZ is not None:
+                self.estCompensatedAccelZ = f"{imu_data_packet.estCompensatedAccelZ:.8f}"
+            if imu_data_packet.estLinearAccelX is not None:
+                self.estLinearAccelX = f"{imu_data_packet.estLinearAccelX:.8f}"
+            if imu_data_packet.estLinearAccelY is not None:
+                self.estLinearAccelY = f"{imu_data_packet.estLinearAccelY:.8f}"
+            if imu_data_packet.estLinearAccelZ is not None:
+                self.estLinearAccelZ = f"{imu_data_packet.estLinearAccelZ:.8f}"
+            if imu_data_packet.estGravityVectorX is not None:
+                self.estGravityVectorX = f"{imu_data_packet.estGravityVectorX:.8f}"
+            if imu_data_packet.estGravityVectorY is not None:
+                self.estGravityVectorY = f"{imu_data_packet.estGravityVectorY:.8f}"
+            if imu_data_packet.estGravityVectorZ is not None:
+                self.estGravityVectorZ = f"{imu_data_packet.estGravityVectorZ:.8f}"
+            if imu_data_packet.estPressureAlt is not None:
+                self.estPressureAlt = f"{imu_data_packet.estPressureAlt:.8f}"
 
         else:
-            if idp.scaledAccelX is not None:
-                self.scaledAccelX = f"{idp.scaledAccelX:.8f}"
-            if idp.scaledAccelY is not None:
-                self.scaledAccelY = f"{idp.scaledAccelY:.8f}"
-            if idp.scaledAccelZ is not None:
-                self.scaledAccelZ = f"{idp.scaledAccelZ:.8f}"
-            if idp.scaledGyroX is not None:
-                self.scaledGyroX = f"{idp.scaledGyroX:.8f}"
-            if idp.scaledGyroY is not None:
-                self.scaledGyroY = f"{idp.scaledGyroY:.8f}"
-            if idp.scaledGyroZ is not None:
-                self.scaledGyroZ = f"{idp.scaledGyroZ:.8f}"
-            if idp.deltaVelX is not None:
-                self.deltaVelX = f"{idp.deltaVelX:.8f}"
-            if idp.deltaVelY is not None:
-                self.deltaVelY = f"{idp.deltaVelY:.8f}"
-            if idp.deltaVelZ is not None:
-                self.deltaVelZ = f"{idp.deltaVelZ:.8f}"
-            if idp.deltaThetaX is not None:
-                self.deltaThetaX = f"{idp.deltaThetaX:.8f}"
-            if idp.deltaThetaY is not None:
-                self.deltaThetaY = f"{idp.deltaThetaY:.8f}"
-            if idp.deltaThetaZ is not None:
-                self.deltaThetaZ = f"{idp.deltaThetaZ:.8f}"
+            if imu_data_packet.scaledAccelX is not None:
+                self.scaledAccelX = f"{imu_data_packet.scaledAccelX:.8f}"
+            if imu_data_packet.scaledAccelY is not None:
+                self.scaledAccelY = f"{imu_data_packet.scaledAccelY:.8f}"
+            if imu_data_packet.scaledAccelZ is not None:
+                self.scaledAccelZ = f"{imu_data_packet.scaledAccelZ:.8f}"
+            if imu_data_packet.scaledGyroX is not None:
+                self.scaledGyroX = f"{imu_data_packet.scaledGyroX:.8f}"
+            if imu_data_packet.scaledGyroY is not None:
+                self.scaledGyroY = f"{imu_data_packet.scaledGyroY:.8f}"
+            if imu_data_packet.scaledGyroZ is not None:
+                self.scaledGyroZ = f"{imu_data_packet.scaledGyroZ:.8f}"
+            if imu_data_packet.deltaVelX is not None:
+                self.deltaVelX = f"{imu_data_packet.deltaVelX:.8f}"
+            if imu_data_packet.deltaVelY is not None:
+                self.deltaVelY = f"{imu_data_packet.deltaVelY:.8f}"
+            if imu_data_packet.deltaVelZ is not None:
+                self.deltaVelZ = f"{imu_data_packet.deltaVelZ:.8f}"
+            if imu_data_packet.deltaThetaX is not None:
+                self.deltaThetaX = f"{imu_data_packet.deltaThetaX:.8f}"
+            if imu_data_packet.deltaThetaY is not None:
+                self.deltaThetaY = f"{imu_data_packet.deltaThetaY:.8f}"
+            if imu_data_packet.deltaThetaZ is not None:
+                self.deltaThetaZ = f"{imu_data_packet.deltaThetaZ:.8f}"
 
         # Common field between the two
-        self.invalid_fields = idp.invalid_fields
+        self.invalid_fields = imu_data_packet.invalid_fields
 
     def set_processed_data_packet_attributes(self, processed_data_packet: ProcessedDataPacket) -> None:
         """

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -58,7 +58,6 @@ class LoggedDataPacket(msgspec.Struct):
     estGravityVectorZ: float | None = None
 
     # Processed Data Packet Fields
-    avg_acceleration: tuple[float, float, float] | None = None
     current_altitude: float | None = None
     speed: float | None = None
     # Not logging maxes because they are easily found
@@ -156,6 +155,5 @@ class LoggedDataPacket(msgspec.Struct):
         """
         Sets the attributes of the data packet corresponding to the processed data packet.
         """
-        self.avg_acceleration = processed_data_packet.avg_acceleration
         self.current_altitude = processed_data_packet.current_altitude
         self.speed = processed_data_packet.speed

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -2,7 +2,7 @@
 
 import msgspec
 
-from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, IMUDataPacket, RawDataPacket
+from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, IMUDataPacket
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 
 
@@ -121,7 +121,7 @@ class LoggedDataPacket(msgspec.Struct):
             if idp.estPressureAlt is not None:
                 self.estPressureAlt = f"{idp.estPressureAlt:.8f}"
 
-        if isinstance(idp, RawDataPacket):
+        else:
             if idp.scaledAccelX is not None:
                 self.scaledAccelX = f"{idp.scaledAccelX:.8f}"
             if idp.scaledAccelY is not None:

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -70,7 +70,6 @@ class LoggedDataPacket(msgspec.Struct):
         This function could be a lot cleaner and just use getattr() and setattr(), but that is
         slower and takes up 15% of the main loop execution time.
 
-        :param ldp: The logged data packet to set the attributes of.
         :param imu_data_packet: The IMU data packet to set the attributes from.
         """
         idp = imu_data_packet

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -6,6 +6,8 @@ import multiprocessing
 import signal
 from pathlib import Path
 
+import msgspec
+
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from constants import LOG_BUFFER_SIZE, LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
 
@@ -74,12 +76,14 @@ class Logger:
     def log(self, logged_data_packets: collections.deque[LoggedDataPacket]) -> None:
         """
         Logs the current state, extension, and IMU data to the CSV file.
+
         :param logged_data_packets: the list of IMU data packets to log
         """
         # Loop through all the IMU data packets
         for logged_data_packet in logged_data_packets:
             # Formats the log message as a CSV line
-            message_dict = {key: getattr(logged_data_packet, key) for key in logged_data_packet.__struct_fields__}
+            # We are populating a dictionary with the fields of the logged data packet
+            message_dict = msgspec.structs.asdict(logged_data_packet)
 
             if logged_data_packet.state in ["S", "L"]:  # S: StandbyState, L: LandedState
                 if self._log_counter < LOG_CAPACITY_AT_STANDBY:
@@ -87,7 +91,7 @@ class Logger:
                     self._log_counter += 1
                 else:
                     self._log_buffer.append(message_dict)
-                    continue
+                    continue  # skip because we don't want to put the message in the queue
             else:
                 if self._log_buffer:
                     # Log the buffer before logging the new message

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -6,7 +6,7 @@ import multiprocessing
 import signal
 from pathlib import Path
 
-import msgspec
+from msgspec.structs import asdict
 
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from constants import LOG_BUFFER_SIZE, LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
@@ -83,7 +83,7 @@ class Logger:
         for logged_data_packet in logged_data_packets:
             # Formats the log message as a CSV line
             # We are populating a dictionary with the fields of the logged data packet
-            message_dict = msgspec.structs.asdict(logged_data_packet)
+            message_dict = asdict(logged_data_packet)
 
             if logged_data_packet.state in ["S", "L"]:  # S: StandbyState, L: LandedState
                 if self._log_counter < LOG_CAPACITY_AT_STANDBY:

--- a/airbrakes/data_handling/processed_data_packet.py
+++ b/airbrakes/data_handling/processed_data_packet.py
@@ -9,6 +9,5 @@ class ProcessedDataPacket(msgspec.Struct):
     data.
     """
 
-    avg_acceleration: tuple[float, float, float]
     current_altitude: float
     speed: float

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -96,9 +96,8 @@ class IMU:
         # We use a deque because it's faster than a list for popping from the left
         data_packets = collections.deque()
         # While there is data in the queue, get the data packet and add it to the dequeue which we return
-        while not self._data_queue.empty():
-            data_packet = self.get_imu_data_packet()
-            data_packets.append(data_packet)
+        for _ in range(self._data_queue.qsize()):
+            data_packets.append(self.get_imu_data_packet())
 
         return data_packets
 

--- a/constants.py
+++ b/constants.py
@@ -71,7 +71,6 @@ TEST_LOGS_PATH = Path("test_logs")
 # see stop() and _logging_loop() for more details.
 STOP_SIGNAL = "STOP"
 
-DATA_PACKET_DECIMAL_PLACES = 8
 
 # Don't log more than x packets for StandbyState and LandedState
 LOG_CAPACITY_AT_STANDBY = 5000

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -54,8 +54,6 @@ class TestIMUDataProcessor:
 
     def test_init(self, data_processor):
         d = IMUDataProcessor([])
-        assert d._avg_accel == (0.0, 0.0, 0.0)
-        assert d._avg_accel_mag == 0.0
         assert d._max_altitude == 0.0
         assert isinstance(d._previous_velocity, np.ndarray)
         assert (d._previous_velocity == np.array([0.0, 0.0, 0.0])).all()
@@ -69,8 +67,6 @@ class TestIMUDataProcessor:
         assert d.upside_down is False
 
         d = data_processor
-        assert d._avg_accel == (1.5, 2.5, 3.5)
-        assert d._avg_accel_mag == np.sqrt(1.5**2 + 2.5**2 + 3.5**2)
         assert d._max_altitude == 0.5
         assert d.current_altitude == 0.5
         assert list(d._current_altitudes) == [-0.5, 0.5]
@@ -83,16 +79,13 @@ class TestIMUDataProcessor:
         assert d.upside_down is False
 
     def test_str(self, data_processor):
-        data_processor._avg_accel = tuple(float(i) for i in data_processor.avg_acceleration)
         data_str = (
             "IMUDataProcessor("
-            f"avg_acceleration=(1.5, 2.5, 3.5), "
-            f"avg_acceleration_mag={np.sqrt(1.5**2 + 2.5**2 + 3.5**2)}, "
             "max_altitude=0.5, "
             "current_altitude=0.5, "
             # See the comment in _calculate_speeds() for why speed is 0 during init.
-            f"speed=0.0, "
-            f"max_speed=0.0)"
+            "speed=0.0, "
+            "max_speed=0.0)"
         )
         assert str(data_processor) == data_str
 
@@ -168,9 +161,6 @@ class TestIMUDataProcessor:
             EstimatedDataPacket(2 * 1e9, estLinearAccelX=2, estLinearAccelY=3, estLinearAccelZ=4, estPressureAlt=30),
         ]
         d.update_data(data_points)
-        assert d._avg_accel == (1.5, 2.5, 3.5) == d.avg_acceleration
-        assert d._avg_accel_mag == math.sqrt(1.5**2 + 2.5**2 + 3.5**2) == d.avg_acceleration_mag
-        assert d.avg_acceleration_z == 3.5
         assert d._data_points == data_points
         assert len(d._current_altitudes) == 2
         assert len(d._speeds) == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,10 +154,12 @@ class TestIntegration:
             state_list = []
             for row in reader:
                 line_number += 1
-                # Check if the state field has only a single letter:
                 state: str = row["state"]
                 timestamp: str = row["timestamp"]
                 extension: str = row["extension"]
+                accel: str = row["estLinearAccelX"] or row["scaledAccelX"]  # raw or est data
+
+                # Check if the state field has only a single letter:
                 assert len(state) == 1
                 if state not in state_list:
                     state_list.append(state)
@@ -168,6 +170,10 @@ class TestIntegration:
 
                 # Check if the extension is a float:
                 assert float(extension) in [ServoExtension.MIN_EXTENSION.value, ServoExtension.MAX_EXTENSION.value]
+
+                # Check if we round our values to 8 decimal places:
+                assert accel.count(".") == 1
+                assert len(accel.split(".")[1]) == 8
 
             # Check if we have a lot of lines in the log file:
             assert line_number > 80_000  # arbitrary value, depends on length of log buffer and flight data.

--- a/tests/test_processed_data_packet.py
+++ b/tests/test_processed_data_packet.py
@@ -6,7 +6,6 @@ from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 @pytest.fixture
 def processed_data_packet():
     return ProcessedDataPacket(
-        avg_acceleration=TestProcessedDataPacket.avg_accel,
         current_altitude=TestProcessedDataPacket.current_altitude,
         speed=TestProcessedDataPacket.speed,
     )
@@ -15,13 +14,11 @@ def processed_data_packet():
 class TestProcessedDataPacket:
     """Tests for the ProcessedDataPacket class."""
 
-    avg_accel = (0.0, 0.0, 0.0)
     current_altitude = 0.0
     speed = 0.0
 
     def test_init(self, processed_data_packet):
         packet = processed_data_packet
-        assert packet.avg_acceleration == self.avg_accel
         assert packet.current_altitude == self.current_altitude
         assert packet.speed == self.speed
 


### PR DESCRIPTION
Improves performance of the main process by about 25% by simply inlining calls, removing unused calculations (average_acceleration), and minimizing usage of `isinstance`, `getattr()`, `setattr()`.

Here is the profiled svg flowchart generated by [`pytest-profiling`](https://pypi.org/project/pytest-profiling/) when running `test_integration.py`. (You should `pip install graphviz` as well if you want to run that locally)

Open the image in a new tab to be able to zoom and scroll:

### Before this change:
![combined](https://github.com/user-attachments/assets/b833eed8-d43d-4f13-af82-8a8ac3ae8575)

Time taken to run `pytest test_integration.py` once: 16.98s

### After this change:
![combined](https://github.com/user-attachments/assets/4d85cc94-69e4-4eee-b862-e61d419bc11f)

Time taken to run `pytest test_integration.py` once: 12.71s


Overall improvement from running `pytest test_integration.py`: **25.14%**