### PR TITLE
Add cpu usage in mock simulation

### DIFF
--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -50,7 +50,7 @@ class Logger:
         self._log_queue: multiprocessing.Queue[dict[str, str] | str] = multiprocessing.Queue()
 
         # Start the logging process
-        self._log_process = multiprocessing.Process(target=self._logging_loop, name="Logger")
+        self._log_process = multiprocessing.Process(target=self._logging_loop, name="Logger Process")
 
     @property
     def is_running(self) -> bool:

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -52,7 +52,7 @@ class IMU:
 
         # Starts the process that fetches data from the IMU
         self._data_fetch_process = multiprocessing.Process(
-            target=self._fetch_data_loop, args=(port, frequency), name="IMU Data Fetch Process"
+            target=self._fetch_data_loop, args=(port, frequency), name="IMU Process"
         )
 
     @property

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -1,7 +1,10 @@
 """File which contains a few basic utility functions which can be reused in the project."""
 
+import multiprocessing
 import time
 from typing import TYPE_CHECKING
+
+import psutil
 
 if TYPE_CHECKING:
     from airbrakes.airbrakes import AirbrakesContext
@@ -44,7 +47,7 @@ def deadband(input_value: float, threshold: float) -> float:
     return input_value
 
 
-def update_display(airbrakes: "AirbrakesContext", start_time: float):
+def update_display(airbrakes: "AirbrakesContext", start_time: float, processes: dict[str, psutil.Process]) -> None:
     """Prints the values from the simulation in a pretty way.
 
     :param airbrakes: The airbrakes context object.
@@ -60,6 +63,21 @@ def update_display(airbrakes: "AirbrakesContext", start_time: float):
     print(f"Current altitude:            {airbrakes.data_processor.current_altitude:<10.2f} m")
     print(f"Max altitude so far:         {airbrakes.data_processor.max_altitude:<10.2f} m")
     print(f"Current airbrakes extension: {airbrakes.current_extension:<10}")
+    print(f"\n{'='*10} REAL TIME CPU LOAD {'='*14}\n")
+    for name, process in processes.items():
+        # The < and > are just used to "justify" the text to the left or right, so it looks nice
+        # The interval argument, if passed, is blocking, so that's why we put it as None
+        print(f"{name:<25} - CPU Usage: {process.cpu_percent(interval=None):>8.2f}%")
 
-    # Move the cursor up 7 lines to overwrite the previous output
-    print(MOVE_CURSOR_UP * 7, end="", flush=True)
+    # Move the cursor up 10 lines to overwrite the previous output
+    print(MOVE_CURSOR_UP * (10 + len(processes)), end="", flush=True)
+
+
+def prepare_process_dict(airbrakes: "AirbrakesContext") -> dict[str, psutil.Process]:
+    all_processes = {}
+    imu_process = airbrakes.imu._data_fetch_process
+    log_process = airbrakes.logger._log_process
+    current_process = multiprocessing.current_process()
+    for p in [imu_process, log_process, current_process]:
+        all_processes[p.name] = psutil.Process(p.pid)
+    return all_processes

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -52,6 +52,7 @@ def update_display(airbrakes: "AirbrakesContext", start_time: float, processes: 
 
     :param airbrakes: The airbrakes context object.
     :param start_time: The time the simulation started, in seconds from epoch.
+    :param processes: A dictionary containing the processes to monitor for cpu usage.
     """
     # Print values with multiple print statements
     # The <10 is used to align the values to the left with a width of 10

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from airbrakes.data_handling.logger import Logger
 from airbrakes.hardware.imu import IMU
 from airbrakes.hardware.servo import Servo
 from airbrakes.mock.mock_imu import MockIMU
-from airbrakes.utils import update_display
+from airbrakes.utils import prepare_process_dict, update_display
 from constants import (
     FREQUENCY,
     LOGS_PATH,
@@ -42,14 +42,19 @@ def main(is_simulation: bool, real_servo: bool) -> None:
     # The context that will manage the airbrakes state machine
     airbrakes = AirbrakesContext(servo, imu, logger, data_processor)
 
+    # Prepare the processes for monitoring in the simulation:
+    if is_simulation:
+        all_processes = prepare_process_dict(airbrakes)
+
     try:
         airbrakes.start()  # Start the IMU and logger processes
+
         # This is the main loop that will run until we press Ctrl+C
         while not airbrakes.shutdown_requested:
             airbrakes.update()
 
             if is_simulation:
-                update_display(airbrakes, sim_time_start)
+                update_display(airbrakes, sim_time_start, all_processes)
     except KeyboardInterrupt:
         pass
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 dev = [
     "pytest",
     "ruff",
+    "psutil",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Allows us to inspect CPU usage to see if any process is being held up while running the mock sim (in real time).

On my PC it shows 0% for all of them most of the time, with some spikes happening mostly for the MockIMU (just reading the csv file)

Will be useful to run on the pi and check.

![image](https://github.com/user-attachments/assets/335a013c-c21c-4682-a624-8ad50defa301)
