### PR TITLE
Tiny performance improvement, type hinting improvements

### DIFF
--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -2,7 +2,7 @@
 
 import msgspec
 
-from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, IMUDataPacket
+from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, RawDataPacket
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 
 
@@ -21,137 +21,137 @@ class LoggedDataPacket(msgspec.Struct):
     invalid_fields: list[str] | None = None
 
     # Raw Data Packet Fields
-    scaledAccelX: float | None = None
-    scaledAccelY: float | None = None
-    scaledAccelZ: float | None = None
-    scaledGyroX: float | None = None
-    scaledGyroY: float | None = None
-    scaledGyroZ: float | None = None
-    deltaVelX: float | None = None
-    deltaVelY: float | None = None
-    deltaVelZ: float | None = None
-    deltaThetaX: float | None = None
-    deltaThetaY: float | None = None
-    deltaThetaZ: float | None = None
+    scaledAccelX: str | None = None
+    scaledAccelY: str | None = None
+    scaledAccelZ: str | None = None
+    scaledGyroX: str | None = None
+    scaledGyroY: str | None = None
+    scaledGyroZ: str | None = None
+    deltaVelX: str | None = None
+    deltaVelY: str | None = None
+    deltaVelZ: str | None = None
+    deltaThetaX: str | None = None
+    deltaThetaY: str | None = None
+    deltaThetaZ: str | None = None
 
     # Estimated Data Packet Fields
-    estOrientQuaternionW: float | None = None
-    estOrientQuaternionX: float | None = None
-    estOrientQuaternionY: float | None = None
-    estOrientQuaternionZ: float | None = None
-    estPressureAlt: float | None = None
-    estAttitudeUncertQuaternionW: float | None = None
-    estAttitudeUncertQuaternionX: float | None = None
-    estAttitudeUncertQuaternionY: float | None = None
-    estAttitudeUncertQuaternionZ: float | None = None
-    estAngularRateX: float | None = None
-    estAngularRateY: float | None = None
-    estAngularRateZ: float | None = None
-    estCompensatedAccelX: float | None = None
-    estCompensatedAccelY: float | None = None
-    estCompensatedAccelZ: float | None = None
-    estLinearAccelX: float | None = None
-    estLinearAccelY: float | None = None
-    estLinearAccelZ: float | None = None
-    estGravityVectorX: float | None = None
-    estGravityVectorY: float | None = None
-    estGravityVectorZ: float | None = None
+    estOrientQuaternionW: str | None = None
+    estOrientQuaternionX: str | None = None
+    estOrientQuaternionY: str | None = None
+    estOrientQuaternionZ: str | None = None
+    estPressureAlt: str | None = None
+    estAttitudeUncertQuaternionW: str | None = None
+    estAttitudeUncertQuaternionX: str | None = None
+    estAttitudeUncertQuaternionY: str | None = None
+    estAttitudeUncertQuaternionZ: str | None = None
+    estAngularRateX: str | None = None
+    estAngularRateY: str | None = None
+    estAngularRateZ: str | None = None
+    estCompensatedAccelX: str | None = None
+    estCompensatedAccelY: str | None = None
+    estCompensatedAccelZ: str | None = None
+    estLinearAccelX: str | None = None
+    estLinearAccelY: str | None = None
+    estLinearAccelZ: str | None = None
+    estGravityVectorX: str | None = None
+    estGravityVectorY: str | None = None
+    estGravityVectorZ: str | None = None
 
     # Processed Data Packet Fields
-    current_altitude: float | None = None
-    speed: float | None = None
+    current_altitude: str | None = None
+    speed: str | None = None
     # Not logging maxes because they are easily found
 
-    def set_imu_data_packet_attributes(self, imu_data_packet: IMUDataPacket) -> None:
+    def set_estimated_data_packet_attributes(self, data_packet: EstimatedDataPacket) -> None:
         """
-        Sets the attributes of the data packet corresponding to the IMU data packet. Rounds the
+        Sets the attributes of the data packet corresponding to the estimated data packet. Rounds the
         float values to 8 decimal places, if the value is a float.
 
         This function could be a lot cleaner and just use getattr() and setattr(), but that is
         slower and takes up 15% of the main loop execution time.
 
-        :param imu_data_packet: The IMU data packet to set the attributes from.
+        :param estimated_data_packet: The estimated data packet to set the attributes from.
         """
-        if isinstance(imu_data_packet, EstimatedDataPacket):
-            # super ugly code, but it results in a 10-14% speedup overall
-            # The speed improvements come from not looping through the fields of the data packet
-            # and using getattr() and setattr() to set the attributes of the logged data packet.
-            # Additionally, rounding using f-strings is faster than round() by about ~25%
-            if imu_data_packet.estOrientQuaternionW is not None:
-                self.estOrientQuaternionW = f"{imu_data_packet.estOrientQuaternionW:.8f}"
-            if imu_data_packet.estOrientQuaternionX is not None:
-                self.estOrientQuaternionX = f"{imu_data_packet.estOrientQuaternionX:.8f}"
-            if imu_data_packet.estOrientQuaternionY is not None:
-                self.estOrientQuaternionY = f"{imu_data_packet.estOrientQuaternionY:.8f}"
-            if imu_data_packet.estOrientQuaternionZ is not None:
-                self.estOrientQuaternionZ = f"{imu_data_packet.estOrientQuaternionZ:.8f}"
-            if imu_data_packet.estAttitudeUncertQuaternionW is not None:
-                self.estAttitudeUncertQuaternionW = f"{imu_data_packet.estAttitudeUncertQuaternionW:.8f}"
-            if imu_data_packet.estAttitudeUncertQuaternionX is not None:
-                self.estAttitudeUncertQuaternionX = f"{imu_data_packet.estAttitudeUncertQuaternionX:.8f}"
-            if imu_data_packet.estAttitudeUncertQuaternionY is not None:
-                self.estAttitudeUncertQuaternionY = f"{imu_data_packet.estAttitudeUncertQuaternionY:.8f}"
-            if imu_data_packet.estAttitudeUncertQuaternionZ is not None:
-                self.estAttitudeUncertQuaternionZ = f"{imu_data_packet.estAttitudeUncertQuaternionZ:.8f}"
-            if imu_data_packet.estAngularRateX is not None:
-                self.estAngularRateX = f"{imu_data_packet.estAngularRateX:.8f}"
-            if imu_data_packet.estAngularRateY is not None:
-                self.estAngularRateY = f"{imu_data_packet.estAngularRateY:.8f}"
-            if imu_data_packet.estAngularRateZ is not None:
-                self.estAngularRateZ = f"{imu_data_packet.estAngularRateZ:.8f}"
-            if imu_data_packet.estCompensatedAccelX is not None:
-                self.estCompensatedAccelX = f"{imu_data_packet.estCompensatedAccelX:.8f}"
-            if imu_data_packet.estCompensatedAccelY is not None:
-                self.estCompensatedAccelY = f"{imu_data_packet.estCompensatedAccelY:.8f}"
-            if imu_data_packet.estCompensatedAccelZ is not None:
-                self.estCompensatedAccelZ = f"{imu_data_packet.estCompensatedAccelZ:.8f}"
-            if imu_data_packet.estLinearAccelX is not None:
-                self.estLinearAccelX = f"{imu_data_packet.estLinearAccelX:.8f}"
-            if imu_data_packet.estLinearAccelY is not None:
-                self.estLinearAccelY = f"{imu_data_packet.estLinearAccelY:.8f}"
-            if imu_data_packet.estLinearAccelZ is not None:
-                self.estLinearAccelZ = f"{imu_data_packet.estLinearAccelZ:.8f}"
-            if imu_data_packet.estGravityVectorX is not None:
-                self.estGravityVectorX = f"{imu_data_packet.estGravityVectorX:.8f}"
-            if imu_data_packet.estGravityVectorY is not None:
-                self.estGravityVectorY = f"{imu_data_packet.estGravityVectorY:.8f}"
-            if imu_data_packet.estGravityVectorZ is not None:
-                self.estGravityVectorZ = f"{imu_data_packet.estGravityVectorZ:.8f}"
-            if imu_data_packet.estPressureAlt is not None:
-                self.estPressureAlt = f"{imu_data_packet.estPressureAlt:.8f}"
+        # super ugly code, but it results in a 10-14% speedup overall
+        # The speed improvements come from not looping through the fields of the data packet
+        # and using getattr() and setattr() to set the attributes of the logged data packet.
+        # Additionally, rounding using f-strings is faster than round() by about ~25%
+        if data_packet.estOrientQuaternionW is not None:
+            self.estOrientQuaternionW = f"{data_packet.estOrientQuaternionW:.8f}"
+        if data_packet.estOrientQuaternionX is not None:
+            self.estOrientQuaternionX = f"{data_packet.estOrientQuaternionX:.8f}"
+        if data_packet.estOrientQuaternionY is not None:
+            self.estOrientQuaternionY = f"{data_packet.estOrientQuaternionY:.8f}"
+        if data_packet.estOrientQuaternionZ is not None:
+            self.estOrientQuaternionZ = f"{data_packet.estOrientQuaternionZ:.8f}"
+        if data_packet.estAttitudeUncertQuaternionW is not None:
+            self.estAttitudeUncertQuaternionW = f"{data_packet.estAttitudeUncertQuaternionW:.8f}"
+        if data_packet.estAttitudeUncertQuaternionX is not None:
+            self.estAttitudeUncertQuaternionX = f"{data_packet.estAttitudeUncertQuaternionX:.8f}"
+        if data_packet.estAttitudeUncertQuaternionY is not None:
+            self.estAttitudeUncertQuaternionY = f"{data_packet.estAttitudeUncertQuaternionY:.8f}"
+        if data_packet.estAttitudeUncertQuaternionZ is not None:
+            self.estAttitudeUncertQuaternionZ = f"{data_packet.estAttitudeUncertQuaternionZ:.8f}"
+        if data_packet.estAngularRateX is not None:
+            self.estAngularRateX = f"{data_packet.estAngularRateX:.8f}"
+        if data_packet.estAngularRateY is not None:
+            self.estAngularRateY = f"{data_packet.estAngularRateY:.8f}"
+        if data_packet.estAngularRateZ is not None:
+            self.estAngularRateZ = f"{data_packet.estAngularRateZ:.8f}"
+        if data_packet.estCompensatedAccelX is not None:
+            self.estCompensatedAccelX = f"{data_packet.estCompensatedAccelX:.8f}"
+        if data_packet.estCompensatedAccelY is not None:
+            self.estCompensatedAccelY = f"{data_packet.estCompensatedAccelY:.8f}"
+        if data_packet.estCompensatedAccelZ is not None:
+            self.estCompensatedAccelZ = f"{data_packet.estCompensatedAccelZ:.8f}"
+        if data_packet.estLinearAccelX is not None:
+            self.estLinearAccelX = f"{data_packet.estLinearAccelX:.8f}"
+        if data_packet.estLinearAccelY is not None:
+            self.estLinearAccelY = f"{data_packet.estLinearAccelY:.8f}"
+        if data_packet.estLinearAccelZ is not None:
+            self.estLinearAccelZ = f"{data_packet.estLinearAccelZ:.8f}"
+        if data_packet.estGravityVectorX is not None:
+            self.estGravityVectorX = f"{data_packet.estGravityVectorX:.8f}"
+        if data_packet.estGravityVectorY is not None:
+            self.estGravityVectorY = f"{data_packet.estGravityVectorY:.8f}"
+        if data_packet.estGravityVectorZ is not None:
+            self.estGravityVectorZ = f"{data_packet.estGravityVectorZ:.8f}"
+        if data_packet.estPressureAlt is not None:
+            self.estPressureAlt = f"{data_packet.estPressureAlt:.8f}"
 
-        else:
-            if imu_data_packet.scaledAccelX is not None:
-                self.scaledAccelX = f"{imu_data_packet.scaledAccelX:.8f}"
-            if imu_data_packet.scaledAccelY is not None:
-                self.scaledAccelY = f"{imu_data_packet.scaledAccelY:.8f}"
-            if imu_data_packet.scaledAccelZ is not None:
-                self.scaledAccelZ = f"{imu_data_packet.scaledAccelZ:.8f}"
-            if imu_data_packet.scaledGyroX is not None:
-                self.scaledGyroX = f"{imu_data_packet.scaledGyroX:.8f}"
-            if imu_data_packet.scaledGyroY is not None:
-                self.scaledGyroY = f"{imu_data_packet.scaledGyroY:.8f}"
-            if imu_data_packet.scaledGyroZ is not None:
-                self.scaledGyroZ = f"{imu_data_packet.scaledGyroZ:.8f}"
-            if imu_data_packet.deltaVelX is not None:
-                self.deltaVelX = f"{imu_data_packet.deltaVelX:.8f}"
-            if imu_data_packet.deltaVelY is not None:
-                self.deltaVelY = f"{imu_data_packet.deltaVelY:.8f}"
-            if imu_data_packet.deltaVelZ is not None:
-                self.deltaVelZ = f"{imu_data_packet.deltaVelZ:.8f}"
-            if imu_data_packet.deltaThetaX is not None:
-                self.deltaThetaX = f"{imu_data_packet.deltaThetaX:.8f}"
-            if imu_data_packet.deltaThetaY is not None:
-                self.deltaThetaY = f"{imu_data_packet.deltaThetaY:.8f}"
-            if imu_data_packet.deltaThetaZ is not None:
-                self.deltaThetaZ = f"{imu_data_packet.deltaThetaZ:.8f}"
-
-        # Common field between the two
-        self.invalid_fields = imu_data_packet.invalid_fields
+    def set_raw_data_packet_attributes(self, data_packet: RawDataPacket) -> None:
+        """
+        Sets the attributes of the data packet corresponding to the raw data packet. Rounds the
+        float values to 8 decimal places, if the value is a float.
+        """
+        if data_packet.scaledAccelX is not None:
+            self.scaledAccelX = f"{data_packet.scaledAccelX:.8f}"
+        if data_packet.scaledAccelY is not None:
+            self.scaledAccelY = f"{data_packet.scaledAccelY:.8f}"
+        if data_packet.scaledAccelZ is not None:
+            self.scaledAccelZ = f"{data_packet.scaledAccelZ:.8f}"
+        if data_packet.scaledGyroX is not None:
+            self.scaledGyroX = f"{data_packet.scaledGyroX:.8f}"
+        if data_packet.scaledGyroY is not None:
+            self.scaledGyroY = f"{data_packet.scaledGyroY:.8f}"
+        if data_packet.scaledGyroZ is not None:
+            self.scaledGyroZ = f"{data_packet.scaledGyroZ:.8f}"
+        if data_packet.deltaVelX is not None:
+            self.deltaVelX = f"{data_packet.deltaVelX:.8f}"
+        if data_packet.deltaVelY is not None:
+            self.deltaVelY = f"{data_packet.deltaVelY:.8f}"
+        if data_packet.deltaVelZ is not None:
+            self.deltaVelZ = f"{data_packet.deltaVelZ:.8f}"
+        if data_packet.deltaThetaX is not None:
+            self.deltaThetaX = f"{data_packet.deltaThetaX:.8f}"
+        if data_packet.deltaThetaY is not None:
+            self.deltaThetaY = f"{data_packet.deltaThetaY:.8f}"
+        if data_packet.deltaThetaZ is not None:
+            self.deltaThetaZ = f"{data_packet.deltaThetaZ:.8f}"
 
     def set_processed_data_packet_attributes(self, processed_data_packet: ProcessedDataPacket) -> None:
         """
         Sets the attributes of the data packet corresponding to the processed data packet.
         """
-        self.current_altitude = processed_data_packet.current_altitude
-        self.speed = processed_data_packet.speed
+        self.current_altitude = f"{processed_data_packet.current_altitude:.8f}"
+        self.speed = f"{processed_data_packet.speed:.8f}"

--- a/airbrakes/data_handling/logged_data_packet.py
+++ b/airbrakes/data_handling/logged_data_packet.py
@@ -123,6 +123,7 @@ class LoggedDataPacket(msgspec.Struct):
         """
         Sets the attributes of the data packet corresponding to the raw data packet. Rounds the
         float values to 8 decimal places, if the value is a float.
+        :param data_packet: The raw data packet to set the attributes from.
         """
         if data_packet.scaledAccelX is not None:
             self.scaledAccelX = f"{data_packet.scaledAccelX:.8f}"

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from msgspec.structs import asdict
 
-from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, IMUDataPacket
+from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, RawDataPacket
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
 from constants import LOG_BUFFER_SIZE, LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
@@ -87,7 +87,7 @@ class Logger:
         self,
         state: str,
         extension: float,
-        imu_data_packets: deque[IMUDataPacket],
+        imu_data_packets: deque[EstimatedDataPacket | RawDataPacket],
         processed_data_packets: deque[ProcessedDataPacket],
     ) -> None:
         """
@@ -132,7 +132,7 @@ class Logger:
         self,
         state: str,
         extension: float,
-        imu_data_packets: deque[IMUDataPacket],
+        imu_data_packets: deque[EstimatedDataPacket | RawDataPacket],
         processed_data_packets: deque[ProcessedDataPacket],
     ) -> deque[LoggedDataPacket]:
         """
@@ -149,11 +149,15 @@ class Logger:
         # Then, if the imu data packet is an estimated data packet, it adds the data from the corresponding processed
         # data packet
         for data_packet in imu_data_packets:
-            logged_data_packet = LoggedDataPacket(state, extension, data_packet.timestamp)
-            logged_data_packet.set_imu_data_packet_attributes(data_packet)
+            logged_data_packet = LoggedDataPacket(
+                state, extension, data_packet.timestamp, invalid_fields=data_packet.invalid_fields
+            )
             if isinstance(data_packet, EstimatedDataPacket):
                 # For every estimated data packet, we have a corresponding processed data packet
+                logged_data_packet.set_estimated_data_packet_attributes(data_packet)
                 logged_data_packet.set_processed_data_packet_attributes(processed_data_packets.popleft())
+            else:
+                logged_data_packet.set_raw_data_packet_attributes(data_packet)
 
             logged_data_packets.append(logged_data_packet)
         return logged_data_packets

--- a/airbrakes/mock/mock_logger.py
+++ b/airbrakes/mock/mock_logger.py
@@ -1,5 +1,7 @@
 """Mock Logger class for testing purposes. Currently only used to delete the log file."""
 
+from pathlib import Path
+
 from airbrakes.data_handling.logger import Logger
 
 
@@ -10,7 +12,7 @@ class MockLogger(Logger):
 
     __slots__ = ("delete_log_file",)
 
-    def __init__(self, log_file_path: str, delete_log_file: bool = True):
+    def __init__(self, log_file_path: Path, delete_log_file: bool = True):
         super().__init__(log_file_path)
         self.delete_log_file = delete_log_file
         self._log_process.name = "Mock Logger Process"

--- a/tests/test_logged_data_packet.py
+++ b/tests/test_logged_data_packet.py
@@ -50,8 +50,8 @@ class TestLoggedDataPacket:
     @pytest.mark.parametrize(
         "imu_data_packet",
         [
-            EstimatedDataPacket(timestamp=3.0 + 1e9, invalid_fields=["test_1"]),
-            RawDataPacket(timestamp=4.0 + 1e9, invalid_fields=["test_2"]),
+            EstimatedDataPacket(timestamp=3 * 1e9),
+            RawDataPacket(timestamp=4 * 1e9),
         ],
         ids=["EstimatedDataPacket", "RawDataPacket"],
     )
@@ -66,12 +66,10 @@ class TestLoggedDataPacket:
                 continue  # this is not set in set_imu_data_packet_attributes
             setattr(imu_data_packet, i, 1.2345678910)
 
-        packet.set_imu_data_packet_attributes(imu_data_packet)
-
         if isinstance(imu_data_packet, EstimatedDataPacket):
-            assert packet.invalid_fields == ["test_1"]
+            packet.set_estimated_data_packet_attributes(imu_data_packet)
         else:
-            assert packet.invalid_fields == ["test_2"]
+            packet.set_raw_data_packet_attributes(imu_data_packet)
 
         assert packet.state == "test"
         assert packet.extension == 0.0
@@ -94,8 +92,8 @@ class TestLoggedDataPacket:
         )
 
         packet.set_processed_data_packet_attributes(proc_data_packet)
-        assert packet.current_altitude == 1.0923457654
-        assert packet.speed == 1.6768972567
+        assert packet.current_altitude == "1.09234577"
+        assert packet.speed == "1.67689726"
         assert packet.timestamp == 0.0
         assert packet.state == "test"
         assert packet.extension == 0.0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -377,6 +377,12 @@ class TestLogger:
     ):
         """Tests whether the _create_logged_data_packets method creates the correct LoggedDataPacket objects."""
 
+        # set some invalid fields to test if they stay as a list
+        invalid_field = ["something"]
+        for imu_packet in imu_data_packets:
+            imu_packet.invalid_fields = invalid_field
+        expected_output[0]["invalid_fields"] = invalid_field  # we need to change the output also
+
         logged_data_packets = logger._create_logged_data_packets(
             state, extension, imu_data_packets, processed_data_packets
         )
@@ -388,15 +394,14 @@ class TestLogger:
             converted = {k: v for k, v in msgspec.structs.asdict(logged_data_packet).items() if v}
             is_raw_data_packet = converted.get("scaledAccelX", False)
             # certain fields are not converted to strings (intentionally. See logged_data_packet.py)
-            assert isinstance(converted["invalid_fields"], float)
+            assert isinstance(converted["invalid_fields"], list)
             assert isinstance(converted["timestamp"], float)
             if not is_raw_data_packet:
-                assert isinstance(converted["speed"], float)
-                assert isinstance(converted["current_altitude"], float)
+                assert isinstance(converted["speed"], str)
+                assert isinstance(converted["current_altitude"], str)
             assert isinstance(converted["extension"], float)
 
             # convert the above fields for easy assertion check at the end:
-            converted["invalid_fields"] = str(converted["invalid_fields"])
             converted["timestamp"] = str(converted["timestamp"])
             if not is_raw_data_packet:
                 converted["speed"] = str(converted["speed"])


### PR DESCRIPTION
Separates the method for setting `LoggedDataPacket`s attributes from an `IMUDataPacket`, which eliminates one extraneous `isinstance()` call, resulting in a super tiny performance gain.

Some type hinting fixes as well. Also solves a point in #36.