### PR TITLE
Terminate `main.py` after we have landed and hit the buffer

### DIFF
--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -67,6 +67,8 @@ class AirbrakesContext:
         Handles shutting down the airbrakes. This will cause the main loop to break. It retracts the airbrakes, stops
         the IMU, and stops the logger.
         """
+        if self.shutdown_requested:
+            return
         self.retract_airbrakes()
         self.imu.stop()
         self.logger.stop()

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -79,6 +79,8 @@ class Logger:
         """
         Stops the logging process. It will finish logging the current message and then stop.
         """
+        # Log the buffer before stopping the process
+        self._log_the_buffer()
         self._log_queue.put(STOP_SIGNAL)  # Put the stop signal in the queue
         # Waits for the process to finish before stopping it
         self._log_process.join()
@@ -119,14 +121,20 @@ class Logger:
             else:
                 if self._log_buffer:
                     # Log the buffer before logging the new message
-                    for buffered_message in self._log_buffer:
-                        self._log_queue.put(buffered_message)
-                    self._log_buffer.clear()
+                    self._log_the_buffer()
 
                 self._log_counter = 0  # Reset the counter for other states
 
             # Put the message in the queue
             self._log_queue.put(message_dict)
+
+    def _log_the_buffer(self):
+        """
+        Adds the log buffer to the queue, so it can be logged to file.
+        """
+        for buffered_message in self._log_buffer:
+            self._log_queue.put(buffered_message)
+        self._log_buffer.clear()
 
     def _create_logged_data_packets(
         self,

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -11,7 +11,7 @@ from msgspec.structs import asdict
 from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket, IMUDataPacket
 from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
 from airbrakes.data_handling.processed_data_packet import ProcessedDataPacket
-from constants import LOG_BUFFER_SIZE, LOG_CAPACITY_AT_STANDBY, STOP_SIGNAL
+from constants import IDLE_LOG_CAPACITY, LOG_BUFFER_SIZE, STOP_SIGNAL
 
 
 class Logger:
@@ -69,6 +69,13 @@ class Logger:
         """
         return self._log_process.is_alive()
 
+    @property
+    def is_log_buffer_full(self) -> bool:
+        """
+        Returns whether the log buffer is full.
+        """
+        return len(self._log_buffer) == LOG_BUFFER_SIZE
+
     def start(self) -> None:
         """
         Starts the logging process. This is called before the main while loop starts.
@@ -112,7 +119,7 @@ class Logger:
             # If the state is StandbyState or LandedState, we create a buffer for data packets because otherwise
             # we could have gigabytes of data in the log file just for when the rocket is on the ground.
             if logged_data_packet.state in ["S", "L"]:  # S: StandbyState, L: LandedState
-                if self._log_counter < LOG_CAPACITY_AT_STANDBY:
+                if self._log_counter < IDLE_LOG_CAPACITY:
                     # add the count:
                     self._log_counter += 1
                 else:

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -70,8 +70,13 @@ class IMU:
         Stops the process separate from the main process for fetching data from the IMU.
         """
         self._running.value = False
-        # Waits for the process for a maximum of 0.1 seconds to finish before stopping it
-        self._data_fetch_process.join(timeout=0.1)
+        # Fetch all packets which are not yet fetched and discard them, so main() does not get
+        # stuck waiting for the process to finish. A more technical explanation:
+        # .put() is blocking and if the queue is full, it keeps waiting for the queue to be empty, and
+        # thus the process never .joins().
+        self.get_imu_data_packets()
+        self._data_queue.close()
+        self._data_fetch_process.join()
 
     def get_imu_data_packet(self) -> IMUDataPacket | None:
         """

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -70,8 +70,8 @@ class IMU:
         Stops the process separate from the main process for fetching data from the IMU.
         """
         self._running.value = False
-        # Waits for the process to finish before stopping it
-        self._data_fetch_process.join()
+        # Waits for the process for a maximum of 0.1 seconds to finish before stopping it
+        self._data_fetch_process.join(timeout=0.1)
 
     def get_imu_data_packet(self) -> IMUDataPacket | None:
         """

--- a/airbrakes/mock/mock_imu.py
+++ b/airbrakes/mock/mock_imu.py
@@ -1,8 +1,8 @@
 """Module for simulating interacting with the IMU (Inertial measurement unit) on the rocket."""
 
+import contextlib
 import csv
 import multiprocessing
-import signal
 import time
 from pathlib import Path
 
@@ -53,18 +53,15 @@ class MockIMU(IMU):
 
         self._running = multiprocessing.Value("b", False)  # Makes a boolean value that is shared between processes
 
-    def _fetch_data_loop(
-        self, log_file_path: Path, real_time_simulation: bool, start_after_log_buffer: bool = False
-    ) -> None:
+    def _read_file(self, log_file_path: Path, real_time_simulation: bool, start_after_log_buffer: bool = False) -> None:
         """
         Reads the data from the log file and puts it into the shared queue.
-        :param log_file_path: the name of the log file to read data from located in logs/
+        :param log_file_path: the name of the log file to read data from located in scripts/imu_data/
         :param real_time_simulation: Whether to simulate a real flight by sleeping for a set period, or run at full
             speed, e.g. for using it in the CI.
         :param start_after_log_buffer: Whether to send the data packets only after the log buffer
             was filled for Standby state.
         """
-        signal.signal(signal.SIGINT, signal.SIG_IGN)  # Ignore the KeyboardInterrupt signal
 
         start_index = 0
         if start_after_log_buffer:
@@ -136,3 +133,12 @@ class MockIMU(IMU):
                     # Simulate polling interval
                     end_time = time.time()
                     time.sleep(max(0.0, 0.001 - (end_time - start_time)))
+
+    def _fetch_data_loop(
+        self, log_file_path: Path, real_time_simulation: bool, start_after_log_buffer: bool = False
+    ) -> None:
+        """A wrapper function to suppress KeyboardInterrupt exceptions when reading the log file."""
+        # unfortunately, doing the signal handling isn't always reliable, so we need to wrap the function
+        # in a context manager to suppress the KeyboardInterrupt
+        with contextlib.suppress(KeyboardInterrupt):
+            self._read_file(log_file_path, real_time_simulation, start_after_log_buffer)

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -10,6 +10,7 @@ from constants import (
     GROUND_ALTITUDE,
     MAX_SPEED_THRESHOLD,
     MOTOR_BURN_TIME,
+    SHUTDOWN_DELAY,
     TAKEOFF_HEIGHT,
     TAKEOFF_SPEED,
 )
@@ -188,10 +189,20 @@ class LandedState(State):
     When the rocket has landed.
     """
 
-    __slots__ = ()
+    __slots__ = ("start_time",)
+
+    def __init__(self, context: "AirbrakesContext"):
+        super().__init__(context)
+        # The start time is used to calculate how long the rocket was in the landed state:
+        self.start_time = time.time()
 
     def update(self):
-        """Nothing to check, we just wait for the rocket to be recovered."""
+        """We use this method to stop the airbrakes system after a certain amount of time."""
+
+        time_in_landed_state = time.time() - self.start_time
+
+        if time_in_landed_state > SHUTDOWN_DELAY:
+            self.context.stop()
 
     def next_state(self):
         # Explicitly do nothing, there is no next state

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -10,7 +10,6 @@ from constants import (
     GROUND_ALTITUDE,
     MAX_SPEED_THRESHOLD,
     MOTOR_BURN_TIME,
-    SHUTDOWN_DELAY,
     TAKEOFF_HEIGHT,
     TAKEOFF_SPEED,
 )
@@ -189,19 +188,12 @@ class LandedState(State):
     When the rocket has landed.
     """
 
-    __slots__ = ("start_time",)
-
-    def __init__(self, context: "AirbrakesContext"):
-        super().__init__(context)
-        # The start time is used to calculate how long the rocket was in the landed state:
-        self.start_time = time.time()
+    __slots__ = ()
 
     def update(self):
-        """We use this method to stop the airbrakes system after a certain amount of time."""
+        """We use this method to stop the airbrakes system after we have hit our log buffer."""
 
-        time_in_landed_state = time.time() - self.start_time
-
-        if time_in_landed_state > SHUTDOWN_DELAY:
+        if self.context.logger.is_log_buffer_full:
             self.context.stop()
 
     def next_state(self):

--- a/constants.py
+++ b/constants.py
@@ -73,7 +73,7 @@ STOP_SIGNAL = "STOP"
 
 
 # Don't log more than x packets for StandbyState and LandedState
-LOG_CAPACITY_AT_STANDBY = 5000  # This is equal to (x/2 + x = 3x/2 = 5000 => x = 3333 = 3.33 secs of data)
+IDLE_LOG_CAPACITY = 5000  # This is equal to (x/2 + x = 3x/2 = 5000 => x = 3333 = 3.33 secs of data)
 # Buffer size if CAPACITY is reached. Once the state changes, this buffer will be logged to make sure we don't lose data
 LOG_BUFFER_SIZE = 5000
 
@@ -107,10 +107,6 @@ DISTANCE_FROM_APOGEE = 100  # meters
 
 # Consider the rocket to have landed if it is within 15 meters of the launch site height.
 GROUND_ALTITUDE = 15.0  # meters
-
-# Landing to shutdown:
-# The time to wait after landing before shutting down:
-SHUTDOWN_DELAY = 5  # seconds
 
 # -------------------------------------------------------
 # Apogee Prediction Configuration

--- a/constants.py
+++ b/constants.py
@@ -108,6 +108,10 @@ DISTANCE_FROM_APOGEE = 100  # meters
 # Consider the rocket to have landed if it is within 15 meters of the launch site height.
 GROUND_ALTITUDE = 15.0  # meters
 
+# Landing to shutdown:
+# The time to wait after landing before shutting down:
+SHUTDOWN_DELAY = 5  # seconds
+
 # -------------------------------------------------------
 # Apogee Prediction Configuration
 # -------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -75,13 +75,17 @@ def main(args: argparse.Namespace) -> None:
                     flight_display.update_display()
                 # Stop the sim when the data is exhausted:
                 if not airbrakes.imu._data_fetch_process.is_alive():
-                    flight_display.update_display(end_sim=FlightDisplay.NATURAL_END)
                     break
-    except KeyboardInterrupt:
+    except KeyboardInterrupt:  # This is run if we press Ctrl+C:
         if args.mock:
             flight_display.update_display(end_sim=FlightDisplay.INTERRUPTED_END)
+    else:  # This is run if we have landed and the program is not interrupted (see state.py)
+        if args.mock:
+            # Usually the mock sim will stop itself due to data exhaustion, so we will actually
+            # hit the condition above, but if the data isn't exhausted, we will stop it here.
+            flight_display.update_display(end_sim=FlightDisplay.NATURAL_END)
     finally:
-        airbrakes.stop()
+        airbrakes.stop()  # Stop the airbrakes system no matter what path we took
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ def main(args: argparse.Namespace) -> None:
             # hit the condition above, but if the data isn't exhausted, we will stop it here.
             flight_display.end_sim_natural.set()
     finally:
-        if args.mock:
+        if args.mock and not args.debug:
             flight_display.stop()
         airbrakes.stop()
 

--- a/tests/test_imu.py
+++ b/tests/test_imu.py
@@ -57,14 +57,18 @@ class TestIMU:
 
         def _fetch_data_loop(self, port: str, frequency: int):
             """Monkeypatched method for testing."""
+            self._data_queue.put(EstimatedDataPacket(timestamp=0))
 
         monkeypatch.setattr(IMU, "_fetch_data_loop", _fetch_data_loop)
         imu = IMU(port=PORT, frequency=FREQUENCY)
         imu.start()
+        time.sleep(0.01)  # Sleep a bit to let the process start and put the data
+        assert imu._data_queue.qsize() == 1
         imu.stop()
         assert not imu._running.value
         assert not imu.is_running
         assert not imu._data_fetch_process.is_alive()
+        assert not imu._data_queue.qsize()
 
     def test_imu_ctrl_c_handling(self, monkeypatch):
         """Tests whether the IMU's stop() handles Ctrl+C fine."""
@@ -123,7 +127,6 @@ class TestIMU:
         imu = random_data_mock_imu
         imu.start()
         time.sleep(0.3)
-        imu.stop()
         # Theoretical number of packets in 0.3s:
         # 300ms / 2ms + 300ms / 1ms = 150 + 300 = 450
         assert imu._data_queue.qsize() > 400, "Queue should have more than 400 packets in 0.3s"
@@ -134,6 +137,7 @@ class TestIMU:
         assert isinstance(packets, deque)
         assert isinstance(packets[0], IMUDataPacket)
         assert imu._data_queue.empty()
+        imu.stop()
 
         # Assert ratio of EstimatedDataPackets to RawDataPackets is roughly 2:1:
         est_count = 0


### PR DESCRIPTION
Closes #53 

The interest launch data only logged 3,917 packets (equivalent to 2.61 seconds) in the `LandedState`, which means the internal OS writing buffer kicked in, which prevented writing the full 5000 packets. Luckily, we still got touchdown data. 

This PR will resolve this issue by terminating the script after we have hit the log buffer in `LandedState`. The winter launch 2023 data (december) hits this log buffer in the `LandedState` and then auto terminates. You can check this by running `main.py -m -l -f` and comparing the number of lines in LandedState in the log file generated.

So now we should get exactly 10,000 data packets in the `LandedState`.