### PR TITLE
Simulate touchdown in interest launch csv

### DIFF
--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -115,7 +115,6 @@ class IMUDataProcessor:
         self._time_differences = self._calculate_time_differences()
 
         self._rotated_accelerations = self._calculate_rotated_accelerations()
-        # print(f"The final rotated acceleration is: {self._rotated_accelerations[-1]}")
         self._vertical_velocities = self._calculate_vertical_velocity()
         self._max_vertical_velocity = max(
             self._vertical_velocities.max(), self._max_vertical_velocity

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -115,6 +115,7 @@ class IMUDataProcessor:
         self._time_differences = self._calculate_time_differences()
 
         self._rotated_accelerations = self._calculate_rotated_accelerations()
+        # print(f"The final rotated acceleration is: {self._rotated_accelerations[-1]}")
         self._vertical_velocities = self._calculate_vertical_velocity()
         self._max_vertical_velocity = max(
             self._vertical_velocities.max(), self._max_vertical_velocity

--- a/launch_data/README.md
+++ b/launch_data/README.md
@@ -2,5 +2,8 @@ This folder contains the launch data of actual previous flights. These are used 
 
 ## Data
 
-1. `interest_launch.csv`: This is the data from the Interest Launch, on September 28th, 2024. The gravity fields were seperately added on later.
-2. `purple_launch.csv`: This is the data from the Purple Nurple launch, on 16th December, 2023. The quaternions, and angular rates fields were seperately added on later.
+1. `interest_launch.csv`: This is the data from the Interest Launch, on September 28th, 2024. The gravity fields were seperately added on later. The
+    "G" state is generated packets. Since we didn't get touchdown data in landed state, we generated a few packets to simulate the touchdown.
+    See #59 and #78 for more details.
+2. `purple_launch.csv`: This is the data from the Purple Nurple launch, on 16th December, 2023. The quaternions, and angular rates fields were seperately
+    added on later. We do have touchdown data for this launch, however since our rotation data is not accurate, we cannot get a good velocity estimate, and thus the landed state does not trigger. There is no workaround for this, other than using acceleration data to switch to landed state.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,7 +124,7 @@ class TestIntegration:
         # Let's validate our data!
 
         # Check we have all the states:
-        if launch_name != "interest_launch":
+        if launch_name == "purple_launch":
             # Our Launches don't properly log/reach the LandedState, so we will ignore it for now.
             assert len(states_dict) == 4
             assert list(states_dict.keys()) == [
@@ -181,7 +181,7 @@ class TestIntegration:
         # We should hit target apogee, and then deploy airbrakes:
         assert any(ext == ServoExtension.MAX_EXTENSION for ext in coast_state.extensions)
 
-        if launch_name != "interest_launch":
+        if launch_name == "purple_launch":
             # High errors for other flights, because we don't have good rotation data.
             assert free_fall_state.min_velocity <= -300.0
         else:
@@ -194,7 +194,7 @@ class TestIntegration:
         assert free_fall_state.min_altitude <= GROUND_ALTITUDE + 10.0
         assert all(ext == ServoExtension.MIN_EXTENSION for ext in free_fall_state.extensions)
 
-        if launch_name == "interest_launch":
+        if launch_name != "purple_launch":
             # Generated data for simulated landing for interest launcH:
             landed_state = states_dict.LandedState
             assert landed_state.min_velocity >= -LANDED_SPEED
@@ -258,7 +258,7 @@ class TestIntegration:
             assert line_number > 80_000
 
             # Check if all states were logged:
-            if launch_name != "interest_launch":
+            if launch_name == "purple_launch":
                 assert state_list == ["S", "M", "C", "F"]
             else:
                 assert state_list == ["S", "M", "C", "F", "L"]


### PR DESCRIPTION
Adds about 2.7 seconds worth of landed state data in the interest launch, so our landed state is triggered in the mock sim and integration test. 

Most packet fields are just repeated, except for timestamp, estCompensatedAccelZ, and estPressureAlt.

The script for this is here for reference:

<details>
<summary> packet script </summary>

```python
import csv
import msgspec
import numpy as np

from airbrakes.data_handling.logged_data_packet import LoggedDataPacket
from utils import convert_to_float, convert_to_nanoseconds
from pathlib import Path
from airbrakes.data_handling.imu_data_packet import RawDataPacket, EstimatedDataPacket


def get_last_estimated_and_raw_packet(log_file_path: Path) -> tuple[EstimatedDataPacket, dict[str, str], RawDataPacket, dict[str, str]]:
    with log_file_path.open(newline="") as csvfile:
        reader = csv.DictReader(csvfile)

        # Reads each row as a dictionary
        row: dict[str, str]
        for row in reader:
            fields_dict = {}
            scaled_accel_x = row.get("scaledAccelX")  # raw data packet field
            est_linear_accel_x = row.get("estLinearAccelX")  # estimated data packet field
            # Create the data packet based on the row
            if scaled_accel_x:
                for key in RawDataPacket.__struct_fields__:
                    val = row.get(key, None)
                    if val:
                        fields_dict[key] = convert_to_float(val)
                fields_dict["timestamp"] = convert_to_nanoseconds(row["timestamp"])
                raw_row = row
                raw_data_packet = RawDataPacket(**fields_dict)
            elif est_linear_accel_x:
                for key in EstimatedDataPacket.__struct_fields__:
                    val = row.get(key, None)
                    if val:
                        fields_dict[key] = convert_to_float(val)
                fields_dict["timestamp"] = convert_to_nanoseconds(row["timestamp"])
                est_row = row
                est_data_packet = EstimatedDataPacket(**fields_dict)
    return est_data_packet, est_row, raw_data_packet, raw_row

def generate_touchdown_acceleration(num_packets, peak_accel=-80, noise_level=0.5):
    """
    Generates a sharp touchdown acceleration curve resembling a normal distribution with noise.
    
    Parameters:
    - num_packets (int): The number of data packets (samples) to generate.
    - peak_accel (float): The peak acceleration value, representing the intensity of touchdown (in m/s^2).
    - noise_level (float): The standard deviation of noise added to the acceleration values.
    
    Returns:
    - np.ndarray: Array of simulated acceleration values representing a touchdown event.
    """
    # Generate a symmetric Gaussian-like curve for the touchdown event
    x = np.linspace(-10, 10, num_packets)  # Spread the x values for sharpness control
    base_accel = np.exp(-x**2) * peak_accel  # Apply Gaussian shape with a negative peak for downward accel

    # Add noise to simulate real-world sensor variability
    noise = np.random.normal(0, noise_level, num_packets)
    touchdown_accel = base_accel + noise

    # Return the generated touchdown acceleration values
    return touchdown_accel


def generate_touchdown_packets(csv_path):
    est_packet, est_row, raw_packet, raw_row = get_last_estimated_and_raw_packet(csv_path)
    # Generate simulated landing packets
    packets = []
    landing_duration = 2.7  # Simulate seconds of extra data in landed state 
    packet_interval = 1 / 1000  # 1000 Hz frequency for raw packets
    est_packet_interval = 1 / 500 # 500 Hz frequency for estimated packets
    total_est_packets_to_generate = int(landing_duration / est_packet_interval)
    total_raw_packets_to_generate = int(landing_duration / packet_interval)

    # Get last altitude value from the estimated packet.
    alt = est_packet.estPressureAlt
    current_zeroed_altitude = est_row["current_altitude"]
    # Deduct 0.01 m every estimated packet to simulate descent
    future_altitudes = [
        alt - 0.001 * i for i in range(1, total_est_packets_to_generate + 1)
    ]
    landing_event_packets = 0
    touchdown_accels = generate_touchdown_acceleration(total_est_packets_to_generate - landing_event_packets)
    future_compensated_accel_zs = [
        accel + est_packet.estCompensatedAccelZ for accel in touchdown_accels
    ]
    # Add a stable gravity value for the landing event:
    # The final rotated acceleration value in the original interest launch file in the landed
    # state is 11.253 m/s^2. So we need to cancel that out somehow
    # diff = 11.253 + (-10.06556129)
    # gravity = -9.78
    # future_compensated_accel_zs = future_compensated_accel_zs + [gravity + diff] * landing_event_packets
    # print(future_compensated_accel_zs)

    future_estimated_timestamps = [
        est_packet.timestamp + int(i * est_packet_interval * 1e9) for i in range(total_est_packets_to_generate)
    ]

    raw_packets = []
    est_packets= []
    # Generate 1 estimated packet for every 2 raw packets:
    for i in range(total_raw_packets_to_generate):
        raw_data_packet = RawDataPacket(
            timestamp=raw_packet.timestamp + int(i * packet_interval * 1e9),
            scaledAccelX=raw_packet.scaledAccelX,
            scaledAccelY=raw_packet.scaledAccelY,
            scaledAccelZ=raw_packet.scaledAccelZ,
            scaledGyroX=raw_packet.scaledGyroX,
            scaledGyroY=raw_packet.scaledGyroY,
            scaledGyroZ=raw_packet.scaledGyroZ,
        )

        raw_packets.append(raw_data_packet)
    
    for i in range(total_est_packets_to_generate):
        est_data_packet = EstimatedDataPacket(
            timestamp=future_estimated_timestamps[i],
            estPressureAlt=future_altitudes[i],
            estCompensatedAccelZ=future_compensated_accel_zs[i],
            estCompensatedAccelX=est_packet.estCompensatedAccelX,
            estCompensatedAccelY=est_packet.estCompensatedAccelY,
            estLinearAccelX=est_packet.estLinearAccelX,
            estLinearAccelY=est_packet.estLinearAccelY,
            estLinearAccelZ=est_packet.estLinearAccelZ,
            estAttitudeUncertQuaternionW=est_packet.estAttitudeUncertQuaternionW,
            estAttitudeUncertQuaternionX=est_packet.estAttitudeUncertQuaternionX,
            estAttitudeUncertQuaternionY=est_packet.estAttitudeUncertQuaternionY,
            estAttitudeUncertQuaternionZ=est_packet.estAttitudeUncertQuaternionZ,
            estOrientQuaternionW=est_packet.estOrientQuaternionW,
            estOrientQuaternionX=est_packet.estOrientQuaternionX,
            estOrientQuaternionY=est_packet.estOrientQuaternionY,
            estOrientQuaternionZ=est_packet.estOrientQuaternionZ,
            estAngularRateX=est_packet.estAngularRateX,
            estAngularRateY=est_packet.estAngularRateY,
            estAngularRateZ=est_packet.estAngularRateZ,
            estGravityVectorX=est_packet.estGravityVectorX,
            estGravityVectorY=est_packet.estGravityVectorY,
            estGravityVectorZ=est_packet.estGravityVectorZ,
        )
        est_packets.append(est_data_packet)


    # Insert the generated packets into the list in order, starting with est packets. 1 ee packet for every 2 raw packets:
    packets = []
    for i in range(total_raw_packets_to_generate):
        packets.append(est_packets[i // 2])
        packets.append(raw_packets[i])

    return packets


def add_packets_to_csv(csv_path, packets):
    current_field_names = csv.DictReader(csv_path.open("r")).fieldnames
    with csv_path.open("a", newline="") as csvfile:
        writer = csv.DictWriter(csvfile, fieldnames=current_field_names)
        for packet in packets:
            packet_dict = msgspec.structs.asdict(packet)
            ldp = LoggedDataPacket(
                state="G",
                extension=0.0,
                **packet_dict,
            )
            ldp_dict = msgspec.structs.asdict(ldp)
            # drop all fields that are not in the current field names:
            ldp_dict = {k: v for k, v in ldp_dict.items() if k in current_field_names}
            writer.writerow(ldp_dict)

# import matplotlib.pyplot as plt
# # Example usage
# num_packets = 1000  # Length of data packets to match
# touchdown_accel_curve = generate_touchdown_acceleration(num_packets)
# plt.figure(figsize=(10, 6))
# plt.plot(touchdown_accel_curve, label="Simulated Touchdown Acceleration (Z-axis)")
# plt.xlabel("Data Packet Index")
# plt.ylabel("Acceleration (m/s^2)")
# plt.title("Simulated Touchdown Acceleration Curve")
# plt.legend()
# plt.grid(True)
# plt.savefig("touchdown_acceleration.png")

if __name__ == "__main__":
    csv_path = Path("launch_data/interest_launch.csv")
    write_csv_path = Path("interest_launch_copy.csv")
    packets = generate_touchdown_packets(csv_path)
    print(len(packets))
    # print(packets)
    add_packets_to_csv(write_csv_path, packets)
    print("Touchdown packets generated and added to the CSV log file.")
```

</details>