### PR TITLE
Fix LandedState timestamps for genesis launch 1

### DIFF
--- a/launch_data/README.md
+++ b/launch_data/README.md
@@ -8,6 +8,7 @@ This folder contains the launch data of actual previous flights. These are used 
 2. `purple_launch.csv`: This is the data from the Purple Nurple launch, on 16th December, 2023. The quaternions, and angular rates fields were seperately
     added on later. We do have touchdown data for this launch, however since our rotation data is not accurate, we cannot get a good velocity estimate, and thus the landed state does not trigger. There is no workaround for this, other than using acceleration data to switch to landed state.
 3. `genesis_launch_1.csv`: This was our first attempt of a control launch with the Genesis subscale rocket. We tried to have it extend its airbrakes for most of coast and then retract them, but later analysis proved that airbrakes didn't deploy during coast. Additionally, the LandedState was incorrectly detected, so for convenience ~100 mb of useless data has been cropped out of this file.
+The timestamps of the LandedState packets were synced with the timestamps of the last packet in the file.
 4. `genesis_launch_2.csv`: This was our second attempt of a control launch with Genesis. For this one we told the airbrakes to deploy once at around the start of CoastState and did not tell them to retract at all. When we recovered the rocket, the fins were extended, by analysis of launch data shows that the airbrakes didn't deploy in CoastState, and most likely deployed sometime either in FreeFall or once the rocket hit the ground. LandedState was mostly correctly detected.
 
 


### PR DESCRIPTION
Adjusts the timestamps of the `LandedState` packets so that there isn't a "jump" to T+5 mins and the time is therefore continuous.

Merge after #117 