### PR TITLE
Renaming "Mock Sim" to "Mock Replay"

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ AirbrakesV2/
 ## Quick Start
 
 This project strongly recommends using [`uv`](https://docs.astral.sh/uv/) to manage and install
-the project. To quickly run the mock simulation, simply run:
+the project. To quickly run the mock replay, simply run:
 
 ```bash
 uvx --from git+https://github.com/NCSU-High-Powered-Rocketry-Club/AirbrakesV2.git mock
 ```
 
-You should see the mock simulation running with a display!
+You should see the mock replay running with a display!
 
 _Note: We will continue using `uv` for the rest of this README, if you don't want to use `uv`, you can set up the project using Python. See [Legacy Project Setup](legacy_project_setup.md) for more information._
 
@@ -191,12 +191,12 @@ cd AirbrakesV2
 uv run mock
 ```
 
-This will install the project, including development dependencies, activate the virtual environment and run the mock simulation.
+This will install the project, including development dependencies, activate the virtual environment and run the mock replay.
 
 _Note: It is important to use `uv run` instead of `uvx` since the `uvx` environment is isolated from
 the project. See the [uv documentation](https://docs.astral.sh/uv/concepts/tools/#relationship-to-uv-run) for more information._
 
-_Note 2: The more "correct" command to run is `uv sync`. This will install the project and its dependencies, but not run the mock simulation._
+_Note 2: The more "correct" command to run is `uv sync`. This will install the project and its dependencies, but not run the mock replay._
 
 ### 3. Install the pre-commit hook:
 ```

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -43,7 +43,7 @@ class DisplayEndingType(StrEnum):
     """
 
     NATURAL = "natural"
-    """The display ends naturally, when the rocket lands, in a mock sim."""
+    """The display ends naturally, when the rocket lands, in a mock replay."""
     INTERRUPTED = "interrupted"
     """The display ends because the user interrupted the program."""
     TAKEOFF = "takeoff"

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -8,7 +8,7 @@ import sys
 # mscl is annoying and we really just have it installed on the pi
 with contextlib.suppress(ImportError):
     import mscl
-    # We should print a warning, but that messes with how the sim display looks
+    # We should print a warning, but that messes with how the mock replay display looks
 
 # If we are not on windows, we can use the faster_fifo library to speed up the queue operations
 if sys.platform != "win32":

--- a/airbrakes/main.py
+++ b/airbrakes/main.py
@@ -34,12 +34,12 @@ def run_mock_flight() -> None:
 
 
 def run_flight(args: argparse.Namespace) -> None:
-    sim_time_start = time.time()
+    mock_time_start = time.time()
 
     servo, imu, logger, data_processor, apogee_predictor = create_components(args)
     # Initialize the airbrakes context and display
     airbrakes = AirbrakesContext(servo, imu, logger, data_processor, apogee_predictor)
-    flight_display = FlightDisplay(airbrakes, sim_time_start, args)
+    flight_display = FlightDisplay(airbrakes, mock_time_start, args)
 
     # Run the main flight loop
     run_flight_loop(airbrakes, flight_display, args.mock)
@@ -55,9 +55,9 @@ def create_components(
     :return: A tuple containing the servo, IMU, Logger, data processor, and apogee predictor objects
     """
     if args.mock:
-        # Replace hardware with mock objects for simulation
+        # Replace hardware with mock objects for mock replay
         imu = MockIMU(
-            real_time_simulation=not args.fast_simulation,
+            real_time_replay=not args.fast_replay,
             log_file_path=args.path,
         )
         # If using a real servo, use the real servo object, otherwise use a mock servo object
@@ -86,7 +86,7 @@ def run_flight_loop(
     Main flight control loop that runs until shutdown is requested or interrupted.
     :param airbrakes: The airbrakes context managing the state machine.
     :param flight_display: Display interface for flight data.
-    :param is_mock: Whether running in simulation mode.
+    :param is_mock: Whether running in mock replay mode.
     """
     try:
         # Starts the airbrakes system and display
@@ -97,18 +97,18 @@ def run_flight_loop(
             # Update the state machine
             airbrakes.update()
 
-            # Stop the simulation when the data is exhausted
+            # Stop the replay when the data is exhausted
             if is_mock and not airbrakes.imu.is_running:
                 break
 
     # Handle user interrupt gracefully
     except KeyboardInterrupt:
         if is_mock:
-            flight_display.end_sim_interrupted.set()
+            flight_display.end_mock_interrupted.set()
     else:  # This is run if we have landed and the program is not interrupted (see state.py)
         if is_mock:
-            # Stop the mock simulation naturally if not interrupted
-            flight_display.end_sim_natural.set()
+            # Stop the mock replay naturally if not interrupted
+            flight_display.end_mock_natural.set()
     finally:
         # Stop the display and airbrakes
         flight_display.stop()
@@ -121,11 +121,12 @@ if __name__ == "__main__":
 
     # Command line args (after these are run, you can press Ctrl+C to exit the program):
     # python -m airbrakes.main -v: Shows the display with much more data
-    # python -m airbrakes.main -m: Runs a simulation on your computer
-    # python -m airbrakes.main -m -r: Runs a simulation on your computer with the real servo
-    # python -m airbrakes.main -m -l: Runs a simulation on your computer and keeps the log file
-    # after the simulation stops
-    # python -m airbrakes.main -m -f: Runs a simulation on your computer at full speed
-    # python -m airbrakes.main -m -d: Runs a simulation on your computer in debug mode (w/o display)
+    # python -m airbrakes.main -m: Runs a mock replay on your computer
+    # python -m airbrakes.main -m -r: Runs a mock replay on your computer with the real servo
+    # python -m airbrakes.main -m -l: Runs a mock replay on your computer and keeps the log file
+    # after the mock replay stops
+    # python -m airbrakes.main -m -f: Runs a mock replay on your computer at full speed
+    # python -m airbrakes.main -m -d: Runs a mock replay on your computer in debug
+    # mode (w/o display)
     args = arg_parser()
     run_flight(args)

--- a/airbrakes/mock/mock_imu.py
+++ b/airbrakes/mock/mock_imu.py
@@ -41,7 +41,7 @@ class MockIMU(BaseIMU):
 
     def __init__(
         self,
-        real_time_simulation: bool,
+        real_time_replay: bool,
         log_file_path: Path | None = None,
         start_after_log_buffer: bool = True,
     ):
@@ -52,7 +52,7 @@ class MockIMU(BaseIMU):
         We don't call the parent constructor as the IMU class has different parameters, so we
         manually start the process that fetches data from the log file
         :param log_file_path: The path of the log file to read data from.
-        :param real_time_simulation: Whether to simulate a real flight by sleeping for a set
+        :param real_time_replay: Whether to mimmick a real flight by sleeping for a set
         period, or run at full speed, e.g. for using it in the CI.
         :param start_after_log_buffer: Whether to send the data packets only after the log buffer
         was filled for Standby state.
@@ -66,7 +66,7 @@ class MockIMU(BaseIMU):
             root_dir = Path(__file__).parent.parent.parent
             self._log_file_path = next(iter(Path(root_dir / "launch_data").glob("*.csv")))
 
-        # If it's not a real time sim, we limit how big the queue gets when doing an integration
+        # If it's not a real time replay, we limit how big the queue gets when doing an integration
         # test, because we read the file much faster than update(), sometimes resulting thousands
         # of data packets in the queue, which will obviously mess up data processing calculations.
         # We limit it to 15 packets, which is more realistic for a real flight.
@@ -74,18 +74,18 @@ class MockIMU(BaseIMU):
             # On Windows, we use a multiprocessing.Queue because the faster_fifo.Queue is not
             # available on Windows
             data_queue = multiprocessing.Queue(
-                maxsize=MAX_QUEUE_SIZE if real_time_simulation else MAX_FETCHED_PACKETS
+                maxsize=MAX_QUEUE_SIZE if real_time_replay else MAX_FETCHED_PACKETS
             )
 
             data_queue.get_many = partial(get_all_from_queue, data_queue)
         else:
             data_queue: Queue[IMUDataPacket] = Queue(
-                maxsize=MAX_QUEUE_SIZE if real_time_simulation else MAX_FETCHED_PACKETS
+                maxsize=MAX_QUEUE_SIZE if real_time_replay else MAX_FETCHED_PACKETS
             )
         # Starts the process that fetches data from the log file
         data_fetch_process = multiprocessing.Process(
             target=self._fetch_data_loop,
-            args=(self._log_file_path, real_time_simulation, start_after_log_buffer),
+            args=(self._log_file_path, real_time_replay, start_after_log_buffer),
             name="Mock IMU Process",
         )
 
@@ -121,12 +121,12 @@ class MockIMU(BaseIMU):
         return 0
 
     def _read_file(
-        self, log_file_path: Path, real_time_simulation: bool, start_after_log_buffer: bool = False
+        self, log_file_path: Path, real_time_replay: bool, start_after_log_buffer: bool = False
     ) -> None:
         """
         Reads the data from the log file and puts it into the shared queue.
         :param log_file_path: the name of the log file to read data from located in scripts/imu_data
-        :param real_time_simulation: Whether to simulate a real flight by sleeping for a set period,
+        :param real_time_replay: Whether to mimmick a real flight by sleeping for a set period,
         or run at full speed, e.g. for using it in the CI.
         :param start_after_log_buffer: Whether to send the data packets only after the log buffer
         was filled for Standby state.
@@ -171,21 +171,21 @@ class MockIMU(BaseIMU):
             # Put the packet in the queue
             self._data_queue.put(imu_data_packet)
 
-            # sleep only if we are running a real-time simulation
+            # sleep only if we are running a real-time replay
             # Our IMU sends raw data at 1000 Hz, so we sleep for 1 ms between each packet to
             # pretend to be real-time
-            if real_time_simulation and isinstance(imu_data_packet, RawDataPacket):
-                # Simulate polling interval
+            if real_time_replay and isinstance(imu_data_packet, RawDataPacket):
+                # Mimmick polling interval
                 end_time = time.time()
                 time.sleep(max(0.0, RAW_DATA_PACKET_SAMPLING_RATE - (end_time - start_time)))
 
     def _fetch_data_loop(
-        self, log_file_path: Path, real_time_simulation: bool, start_after_log_buffer: bool = False
+        self, log_file_path: Path, real_time_replay: bool, start_after_log_buffer: bool = False
     ) -> None:
         """
         A wrapper function to suppress KeyboardInterrupt exceptions when reading the log file.
         :param log_file_path: the name of the log file to read data from located in scripts/imu_data
-        :param real_time_simulation: Whether to simulate a real flight by sleeping for a set period,
+        :param real_time_replay: Whether to mimmick a real flight by sleeping for a set period,
         or run at full speed.
         :param start_after_log_buffer: Whether to send the data packets only after the log buffer
         was filled for Standby state.
@@ -193,7 +193,7 @@ class MockIMU(BaseIMU):
         # Unfortunately, doing the signal handling isn't always reliable, so we need to wrap the
         # function in a context manager to suppress the KeyboardInterrupt
         with contextlib.suppress(KeyboardInterrupt):
-            self._read_file(log_file_path, real_time_simulation, start_after_log_buffer)
+            self._read_file(log_file_path, real_time_replay, start_after_log_buffer)
 
         # For the mock, once we're done reading the file, we say it is no longer running
         self._running.value = False

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 def get_all_from_queue(self, *args, **kwargs) -> list:
     """Used to get all the items from a queue at once. Only relevant if you are running the mock
-    sim on Windows, as the multiprocessing.Queue doesn't have a `get_many` method"""
+    replay on Windows, as the multiprocessing.Queue doesn't have a `get_many` method"""
     kwargs.pop("max_messages_to_get", None)  # Argument only used in the Linux version
     return [self.get(*args, **kwargs) for _ in range(self.qsize())]
 
@@ -93,7 +93,7 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
     parser.add_argument(
         "-m",
         "--mock",
-        help="Run in simulation mode with mock data and mock servo",
+        help="Run in replay mode with mock data and mock servo",
         action="store_true",
         default=mock_invocation,
     )
@@ -101,7 +101,7 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
     parser.add_argument(
         "-r",
         "--real-servo",
-        help="Run the mock sim with the real servo",
+        help="Run the mock replay with the real servo",
         action="store_true",
         default=False,
     )
@@ -109,15 +109,15 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
     parser.add_argument(
         "-l",
         "--keep-log-file",
-        help="Keep the log file after the mock sim stops",
+        help="Keep the log file after the mock replay stops",
         action="store_true",
         default=False,
     )
 
     parser.add_argument(
         "-f",
-        "--fast-simulation",
-        help="Run the mock sim at full speed instead of in real time.",
+        "--fast-replay",
+        help="Run the mock replay at full speed instead of in real time.",
         action="store_true",
         default=False,
     )
@@ -125,7 +125,7 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
     parser.add_argument(
         "-d",
         "--debug",
-        help="Run the mock sim in debug mode. This will not "
+        help="Run the mock replay in debug mode. This will not "
         "print the flight data and allow you to inspect the values of your print() statements.",
         action="store_true",
         default=False,
@@ -134,7 +134,7 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
     parser.add_argument(
         "-p",
         "--path",
-        help="Define the pathname of flight data to use in mock simulation. Interest Launch data"
+        help="Define the pathname of flight data to use in mock replay. Interest Launch data"
         " is used by default",
         type=Path,
         default=None,
@@ -150,15 +150,12 @@ def arg_parser(mock_invocation: bool = False) -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    # Check if the user has passed any options that are only available in simulation mode:
-    if (
-        any([args.real_servo, args.keep_log_file, args.fast_simulation, args.path])
-        and not args.mock
-    ):
+    # Check if the user has passed any options that are only available in mock replay mode:
+    if any([args.real_servo, args.keep_log_file, args.fast_replay, args.path]) and not args.mock:
         parser.error(
-            "The `--real-servo`, `--keep-log-file`, `--fast-simulation`, and `--path` "
-            "options are only available in simulation mode. Please pass `-m` or `--mock` "
-            "to run in simulation mode."
+            "The `--real-servo`, `--keep-log-file`, `--fast-replay`, and `--path` "
+            "options are only available in mock replay mode. Please pass `-m` or `--mock` "
+            "to run in mock replay mode."
         )
 
     if args.verbose and args.debug:

--- a/launch_data/README.md
+++ b/launch_data/README.md
@@ -1,9 +1,9 @@
-This folder contains the launch data of actual previous flights. These are used to run the mock sim.
+This folder contains the launch data of actual previous flights. These are used to run the mock replay.
 
 ## Data
 
 1. `interest_launch.csv`: This is the data from the Interest Launch, on September 28th, 2024. The gravity fields were seperately added on later, as well as missing quaternion data, and the "invalid_fields". The
-    "G" state is generated packets. Since we didn't get touchdown data in landed state, we generated a few packets to simulate the touchdown.
+    "G" state is generated packets. Since we didn't get touchdown data in landed state, we generated a few packets to mimmick the touchdown.
     See #59 and #78 for more details.
 2. `purple_launch.csv`: This is the data from the Purple Nurple launch, on 16th December, 2023. The quaternions, quaternion uncertainities, and angular rates fields were seperately
     added on later. We do have touchdown data for this launch, however since our rotation data is not accurate, we cannot get a good velocity estimate, and thus the landed state does not trigger. There is no workaround for this, other than using acceleration data to switch to landed state. The quaternion uncertainties are set to a low value for a majority of the flight, except whenever the altitude is between 500 - 600 meters. During this range, we set the quaternion uncertainties to a high value, to test our code.

--- a/launch_data/metadata.json
+++ b/launch_data/metadata.json
@@ -53,7 +53,7 @@
             "log_buffer_index": 5000,
             "apogee_meters": 1856.28
         },
-        "flight_description": "First flight of AirbrakesV2. Airbrakes were coded to deploy automatically after roughly 1 second in CoastState. However they did not deploy due a mechanical issue. LandedState was triggered too early and did not capture touchdown. Generated Data packets were added to file to simulate a touchdown. We missed logging some quaternions because they were reported invalid by the IMU, and were added in during post-processing later."
+        "flight_description": "First flight of AirbrakesV2. Airbrakes were coded to deploy automatically after roughly 1 second in CoastState. However they did not deploy due a mechanical issue. LandedState was triggered too early and did not capture touchdown. Generated Data packets were added to file to mimmick a touchdown. We missed logging some quaternions because they were reported invalid by the IMU, and were added in during post-processing later."
     },
     "genesis_launch_1.csv": {
         "date": "2024-11-16 13:45:58.732",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,9 +80,7 @@ def mock_imu(request):
     """Fixture that returns a MockIMU object with the specified log file."""
     # TODO: Figure out if we can get our rotated accels right even when start_after_log_buffer is
     # False.
-    return MockIMU(
-        log_file_path=request.param, real_time_simulation=False, start_after_log_buffer=True
-    )
+    return MockIMU(log_file_path=request.param, real_time_replay=False, start_after_log_buffer=True)
 
 
 @pytest.fixture
@@ -93,7 +91,7 @@ def mocked_args_parser():
         mock = True
         real_servo = False
         keep_log_file = False
-        fast_simulation = False
+        fast_replay = False
         debug = True
 
     return MockArgs()

--- a/tests/test_airbrakes.py
+++ b/tests/test_airbrakes.py
@@ -219,7 +219,7 @@ class TestAirbrakesContext:
         started_thread = False
 
         def stop_airbrakes():
-            fd.end_sim_interrupted.set()
+            fd.end_mock_interrupted.set()
             fd.stop()
             airbrakes.stop()  # Happens when LandedState requests shutdown in the real flight
             has_airbrakes_stopped.set()

--- a/tests/test_apogee_predictor.py
+++ b/tests/test_apogee_predictor.py
@@ -117,8 +117,8 @@ class TestApogeePredictor:
                     for i in range(70)
                 ],
                 # the velocity and altitude points in this data packet are calculated by hand.
-                # the data packets simulate 0 - 7 seconds, in 0.1 second intervals.
-                # the acceleration has a slope of +0.4 m/s^2 per second, which simulates
+                # the data packets are from 0 - 7 seconds, in 0.1 second intervals.
+                # the acceleration has a slope of +0.4 m/s^2 per second, which recreates
                 # coast phase, going from -10 m/s^2 to -7.2 m/s^2. The expected outcome of this
                 # test is the max of the position function. Because we are curve fitting to a
                 # quartic function though, it's off by a bit, because a quartic function
@@ -127,7 +127,7 @@ class TestApogeePredictor:
                 1177.232574134796,
             ),
         ],
-        ids=["hover_at_altitude", "coast_phase_sim"],
+        ids=["hover_at_altitude", "coast_phase"],
     )
     def test_prediction_loop_no_mock(
         self, threaded_apogee_predictor, processed_data_packets, expected_value

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -13,11 +13,11 @@ from airbrakes.data_handling.imu_data_packet import EstimatedDataPacket
 from tests.auxil.utils import make_est_data_packet
 
 
-def simulate_altitude_sine_wave(
+def generate_altitude_sine_wave(
     n_points=1000, frequency=0.01, amplitude=100, noise_level=3, base_altitude=20
 ):
     """Generates a random distribution of altitudes that follow a sine wave pattern, with some
-    noise added to simulate variations in the readings.
+    noise added to mimmick variations in the readings.
 
     :param n_points: The number of altitude points to generate.
     :param frequency: The frequency of the sine wave.
@@ -410,8 +410,8 @@ class TestIMUDataProcessor:
     def test_max_altitude(self, data_processor):
         """Tests whether the max altitude is correctly calculated even when altitude decreases"""
         d = data_processor
-        altitudes = simulate_altitude_sine_wave(n_points=1000)
-        # run update_data every 10 packets, to simulate actual data processing in real time:
+        altitudes = generate_altitude_sine_wave(n_points=1000)
+        # run update_data every 10 packets, to mimmick actual data processing in real time:
         for i in range(0, len(altitudes), 10):
             d.update(
                 [

--- a/tests/test_imu.py
+++ b/tests/test_imu.py
@@ -111,7 +111,7 @@ class TestIMU:
         assert imu._running.value
         assert imu.is_running
         assert imu._data_fetch_process.is_alive()
-        time.sleep(0.001)  # Give the process time to start and simulate the actual loop
+        time.sleep(0.001)  # Give the process time to start and recreate the actual loop
         # send a KeyboardInterrupt to test if the process stops cleanly
         try:
             raise KeyboardInterrupt


### PR DESCRIPTION
With branch #76 creating an actual flight simulation, I wanted to remove mentions of the word "simulation" and "sim" in our code base, and instead re-label our mock sim as "mock replay" instead. 