### PR TITLE
Using acceleration to switch to motor burn state

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -133,8 +133,6 @@ ACCEL_DEADBAND_METERS_PER_SECOND_SQUARED = 0.35
 like wind or being small bumps can cause this to accumulate even while the rocket is stationary, so
 we deadband the accel to prevent this."""
 
-TAKEOFF_HEIGHT_METERS = 10
-"""The height in meters that the rocket must reach before we consider it to have taken off."""
 TAKEOFF_VELOCITY_METERS_PER_SECOND = 10
 """The velocity in meters per second that the rocket must reach before we consider it to have taken
 off."""

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -138,6 +138,9 @@ TAKEOFF_HEIGHT_METERS = 10
 TAKEOFF_VELOCITY_METERS_PER_SECOND = 10
 """The velocity in meters per second that the rocket must reach before we consider it to have taken
 off."""
+TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED = 25
+"""The acceleration in meters per second squared that the rocket must reach before we consider it
+to have taken off."""
 
 # ---------------- MotorBurn to Coasting ----------------
 MAX_VELOCITY_THRESHOLD = 0.96

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -9,7 +9,6 @@ from airbrakes.constants import (
     MAX_FREE_FALL_SECONDS,
     MAX_VELOCITY_THRESHOLD,
     TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED,
-    TAKEOFF_HEIGHT_METERS,
     TAKEOFF_VELOCITY_METERS_PER_SECOND,
     TARGET_ALTITUDE_METERS,
 )
@@ -88,10 +87,6 @@ class StandbyState(State):
         data = self.context.data_processor
 
         if data.vertical_velocity > TAKEOFF_VELOCITY_METERS_PER_SECOND:
-            self.next_state()
-            return
-
-        if data.current_altitude > TAKEOFF_HEIGHT_METERS:
             self.next_state()
             return
 

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -8,6 +8,7 @@ from airbrakes.constants import (
     LANDED_ACCELERATION_METERS_PER_SECOND_SQUARED,
     MAX_FREE_FALL_SECONDS,
     MAX_VELOCITY_THRESHOLD,
+    TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED,
     TAKEOFF_HEIGHT_METERS,
     TAKEOFF_VELOCITY_METERS_PER_SECOND,
     TARGET_ALTITUDE_METERS,
@@ -91,6 +92,10 @@ class StandbyState(State):
             return
 
         if data.current_altitude > TAKEOFF_HEIGHT_METERS:
+            self.next_state()
+            return
+
+        if data.average_vertical_acceleration > TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED:
             self.next_state()
             return
 

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -81,8 +81,8 @@ class StandbyState(State):
         # For that we can check:
         # 1) Velocity - If the velocity of the rocket is above a threshold, the rocket has
         # launched.
-        # 2) Altitude - If the altitude is above a threshold, the rocket has launched.
-        # Ideally we would directly communicate with the motor, but we don't have that capability.
+        # 2) Acceleration - If the acceleration of the rocket is above a threshold, the rocket has
+        # launched.
 
         data = self.context.data_processor
 

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -86,11 +86,11 @@ class StandbyState(State):
 
         data = self.context.data_processor
 
-        if data.vertical_velocity > TAKEOFF_VELOCITY_METERS_PER_SECOND:
+        if data.average_vertical_acceleration > TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED:
             self.next_state()
             return
 
-        if data.average_vertical_acceleration > TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED:
+        if data.vertical_velocity > TAKEOFF_VELOCITY_METERS_PER_SECOND:
             self.next_state()
             return
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from airbrakes.airbrakes import AirbrakesContext
 from airbrakes.constants import (
     GROUND_ALTITUDE_METERS,
     LANDED_ACCELERATION_METERS_PER_SECOND_SQUARED,
-    TAKEOFF_HEIGHT_METERS,
+    TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED,
     TAKEOFF_VELOCITY_METERS_PER_SECOND,
     ServoExtension,
 )
@@ -118,14 +118,24 @@ class TestIntegration:
                 state_info.max_altitude = max(
                     ab.data_processor.current_altitude, state_info.max_altitude
                 )
-                state_info.min_avg_vertical_acceleration = min(
-                    ab.data_processor.average_vertical_acceleration,
-                    state_info.min_avg_vertical_acceleration,
-                )
                 state_info.max_avg_vertical_acceleration = max(
                     ab.data_processor.average_vertical_acceleration,
                     state_info.max_avg_vertical_acceleration,
                 )
+                if ab.state.name == "MotorBurnState":
+                    # Because the end of motor burn state has really low acceleration, we have to
+                    # check to make sure the maximum velocity isn't too high, which ensures the
+                    # minimum acceleration is the very beginning of the motor burn state.
+                    if state_info.max_velocity <= 25:
+                        state_info.min_avg_vertical_acceleration = min(
+                            ab.data_processor.average_vertical_acceleration,
+                            state_info.min_avg_vertical_acceleration,
+                        )
+                else:
+                    state_info.min_avg_vertical_acceleration = min(
+                        ab.data_processor.average_vertical_acceleration,
+                        state_info.min_avg_vertical_acceleration,
+                    )
 
                 state_info.apogee_prediction.append(ab.apogee_predictor.apogee)
 
@@ -160,16 +170,20 @@ class TestIntegration:
         assert stand_by_state.min_velocity == pytest.approx(0.0, abs=0.1)
         assert stand_by_state.max_velocity <= TAKEOFF_VELOCITY_METERS_PER_SECOND
         assert stand_by_state.min_altitude >= -6.0  # might be negative due to noise/flakiness
-        assert stand_by_state.max_altitude <= TAKEOFF_HEIGHT_METERS
+        assert (
+            stand_by_state.min_avg_vertical_acceleration <= TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED
+        )
         assert not any(stand_by_state.apogee_prediction)
         assert all(ext == ServoExtension.MIN_EXTENSION for ext in stand_by_state.extensions)
 
-        assert motor_burn_state.min_velocity >= TAKEOFF_VELOCITY_METERS_PER_SECOND
+        assert motor_burn_state.max_velocity >= TAKEOFF_VELOCITY_METERS_PER_SECOND
         assert motor_burn_state.max_avg_vertical_acceleration >= 90.0
         assert motor_burn_state.max_velocity <= 300.0  # arbitrary value, we haven't hit Mach 1
-        assert motor_burn_state.min_altitude >= -2.5  # detecting takeoff from velocity data
-        assert motor_burn_state.max_altitude >= TAKEOFF_HEIGHT_METERS
         assert motor_burn_state.max_altitude <= 500.0  # Our motor burn time isn't usually that long
+        assert (
+            motor_burn_state.min_avg_vertical_acceleration
+            >= TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED
+        )
         assert not any(motor_burn_state.apogee_prediction)
         assert all(ext == ServoExtension.MIN_EXTENSION for ext in motor_burn_state.extensions)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -122,20 +122,10 @@ class TestIntegration:
                     ab.data_processor.average_vertical_acceleration,
                     state_info.max_avg_vertical_acceleration,
                 )
-                if ab.state.name == "MotorBurnState":
-                    # Because the end of motor burn state has really low acceleration, we have to
-                    # check to make sure the maximum velocity isn't too high, which ensures the
-                    # minimum acceleration is the very beginning of the motor burn state.
-                    if state_info.max_velocity <= 25:
-                        state_info.min_avg_vertical_acceleration = min(
-                            ab.data_processor.average_vertical_acceleration,
-                            state_info.min_avg_vertical_acceleration,
-                        )
-                else:
-                    state_info.min_avg_vertical_acceleration = min(
-                        ab.data_processor.average_vertical_acceleration,
-                        state_info.min_avg_vertical_acceleration,
-                    )
+                state_info.min_avg_vertical_acceleration = min(
+                    ab.data_processor.average_vertical_acceleration,
+                    state_info.min_avg_vertical_acceleration,
+                )
 
                 state_info.apogee_prediction.append(ab.apogee_predictor.apogee)
 
@@ -181,7 +171,7 @@ class TestIntegration:
         assert motor_burn_state.max_velocity <= 300.0  # arbitrary value, we haven't hit Mach 1
         assert motor_burn_state.max_altitude <= 500.0  # Our motor burn time isn't usually that long
         assert (
-            motor_burn_state.min_avg_vertical_acceleration
+            motor_burn_state.max_avg_vertical_acceleration
             >= TAKEOFF_ACCEL_METERS_PER_SECOND_SQUARED
         )
         assert not any(motor_burn_state.apogee_prediction)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -103,25 +103,25 @@ class TestStandbyState:
         assert standby_state.name == "StandbyState"
 
     @pytest.mark.parametrize(
-        ("current_velocity", "current_altitude", "expected_state"),
+        ("current_velocity", "current_acceleration", "expected_state"),
         [
-            (0.0, 0.0, StandbyState),
+            (0.0, 9.8, StandbyState),
             (0.0, 100.0, MotorBurnState),
             (5.0, 0.3, StandbyState),
-            (11, 7, MotorBurnState),
-            (20, 15, MotorBurnState),
+            (3, 28, MotorBurnState),
+            (30, 15, MotorBurnState),
         ],
         ids=[
             "at_launchpad",
-            "only_alt_update",
-            "slow_alt_update",
+            "only_acc_update",
+            "slow_acc_update",
             "optimal_condition",
             "high_velocity",
         ],
     )
-    def test_update(self, standby_state, current_velocity, current_altitude, expected_state):
+    def test_update(self, standby_state, current_velocity, current_acceleration, expected_state):
         standby_state.context.data_processor._vertical_velocities = [current_velocity]
-        standby_state.context.data_processor._current_altitudes = [current_altitude]
+        standby_state.context.data_processor._rotated_accelerations = [current_acceleration]
         standby_state.update()
         assert isinstance(standby_state.context.state, expected_state)
 


### PR DESCRIPTION
With our current state change, it takes around 50 packets or so to switch into motor burn, but this shortens it down to just 3 or 4. I think 25 m/s^2 is well-within the safe range and won't be triggered prematurely while on the pad. Even if it does, we now have the means of checking that with the display, and can reset it.

I kept the other conditions for velocity and height in there, but I think that we should consider removing at least height.