### PR TITLE
Refactor argument parsing

### DIFF
--- a/airbrakes/main.py
+++ b/airbrakes/main.py
@@ -2,6 +2,7 @@
 and run the main loop."""
 
 import argparse
+import sys
 import time
 
 from gpiozero.pins.mock import MockFactory, MockPWMPin
@@ -26,6 +27,8 @@ from airbrakes.utils import arg_parser
 def run_real_flight() -> None:
     """Entry point for the application to run the real flight. Entered when run with
     `uv run real` or `uvx --from git+... real`."""
+    # Modify sys.argv to include `real` as the first argument:
+    sys.argv.insert(1, "real")
     args = arg_parser()
     run_flight(args)
 
@@ -33,14 +36,18 @@ def run_real_flight() -> None:
 def run_mock_flight() -> None:
     """Entry point for the application to run the mock flight. Entered when run with
     `uvx --from git+... mock` or `uv run mock`."""
-    args = arg_parser(mock_invocation=True)
+    # Modify sys.argv to include `mock` as the first argument:
+    sys.argv.insert(1, "mock")
+    args = arg_parser()
     run_flight(args)
 
 
 def run_sim_flight() -> None:
     """Entry point for the application to run the sim flight. Entered when run with
     `uvx --from git+... sim` or `uv run sim`."""
-    args = arg_parser(mock_invocation=True, sim_invocation=True)
+    # Modify sys.argv to include `sim` as the first argument:
+    sys.argv.insert(1, "sim")
+    args = arg_parser()
     run_flight(args)
 
 
@@ -56,7 +63,7 @@ def run_flight(args: argparse.Namespace) -> None:
         imu.set_airbrakes_status(airbrakes.servo.current_extension)
 
     # Run the main flight loop
-    run_flight_loop(airbrakes, flight_display, args.mock, args.sim)
+    run_flight_loop(airbrakes, flight_display, args.mode == "mock", args.mode == "sim")
 
 
 def create_components(
@@ -68,15 +75,17 @@ def create_components(
     :param args: Command line arguments determining the configuration.
     :return: A tuple containing the servo, IMU, Logger, data processor, and apogee predictor objects
     """
-    if args.mock:
-        # Replace hardware with mock objects for simulation
-        if args.sim:
-            imu = SimIMU(sim_type=args.sim, real_time_replay=not args.fast_replay)
-        else:
+    if args.mode in ("mock", "sim"):
+        if args.mode == "mock":
+            # Replace hardware with mock objects for simulation
             imu = MockIMU(
                 real_time_replay=not args.fast_replay,
                 log_file_path=args.path,
             )
+        else:
+            # Use simulation IMU
+            imu = SimIMU(sim_type=args.scale, real_time_replay=not args.fast_replay)
+
         # If using a real servo, use the real servo object, otherwise use a mock servo object
         servo = (
             Servo(SERVO_PIN)
@@ -85,6 +94,7 @@ def create_components(
         )
         logger = MockLogger(LOGS_PATH, delete_log_file=not args.keep_log_file)
         camera = MockCamera() if not args.real_camera else Camera()
+
     else:
         # Use real hardware components
         servo = Servo(SERVO_PIN)
@@ -145,13 +155,13 @@ if __name__ == "__main__":
     # python -m airbrakes.main [ARGS]
 
     # Command line args (after these are run, you can press Ctrl+C to exit the program):
-    # python -m airbrakes.main -v: Shows the display with much more data
-    # python -m airbrakes.main -m: Runs a mock replay on your computer
-    # python -m airbrakes.main -m -r: Runs a mock replay on your computer with the real servo
-    # python -m airbrakes.main -m -l: Runs a mock replay on your computer and keeps the log file
+    # python -m airbrakes.main real -v: Run a real flight with the display showing much more data
+    # python -m airbrakes.main mock: Runs a mock replay on your computer
+    # python -m airbrakes.main mock -r: Runs a mock replay on your computer with the real servo
+    # python -m airbrakes.main mock -l: Runs a mock replay on your computer and keeps the log file
     # after the mock replay stops
-    # python -m airbrakes.main -m -f: Runs a mock replay on your computer at full speed
-    # python -m airbrakes.main -m -d: Runs a mock replay on your computer in debug
+    # python -m airbrakes.main mock -f: Runs a mock replay on your computer at full speed
+    # python -m airbrakes.main mock -d: Runs a mock replay on your computer in debug
     # mode (w/o display)
     args = arg_parser()
     run_flight(args)

--- a/airbrakes/main.py
+++ b/airbrakes/main.py
@@ -59,9 +59,6 @@ def run_flight(args: argparse.Namespace) -> None:
     airbrakes = AirbrakesContext(servo, imu, camera, logger, data_processor, apogee_predictor)
     flight_display = FlightDisplay(airbrakes, mock_time_start, args)
 
-    if args.sim:
-        imu.set_airbrakes_status(airbrakes.servo.current_extension)
-
     # Run the main flight loop
     run_flight_loop(airbrakes, flight_display, args.mode == "mock", args.mode == "sim")
 

--- a/airbrakes/mock/display.py
+++ b/airbrakes/mock/display.py
@@ -43,7 +43,6 @@ class FlightDisplay:
         "_cpu_usages",
         "_launch_file",
         "_launch_time",
-        "_mock",
         "_processes",
         "_running",
         "_start_time",
@@ -138,7 +137,7 @@ class FlightDisplay:
             self._update_display()
 
             # If we are running a real flight, we will stop the display when the rocket takes off:
-            if not self._args.mock and self._airbrakes.state.name == "MotorBurnState":
+            if self._args.mode == "real" and self._airbrakes.state.name == "MotorBurnState":
                 self._update_display(DisplayEndingType.TAKEOFF)
                 break
 
@@ -197,7 +196,7 @@ class FlightDisplay:
 
         # Prepare output
         output = [
-            f"{Y}{'=' * 15} {'REPLAY' if self._args.mock else 'STANDBY'} INFO {'=' * 15}{RESET}",
+            f"{Y}{'=' * 15} {'REPLAY' if self._args.mode == 'mock' else 'STANDBY'} INFO {'=' * 15}{RESET}",  # noqa: E501
             f"Replay file:                  {C}{self._launch_file}{RESET}",
             f"Time since replay start:      {C}{time.time() - self._start_time:<10.2f}{RESET} {R}s{RESET}",  # noqa: E501
             f"{Y}{'=' * 12} REAL TIME FLIGHT DATA {'=' * 12}{RESET}",

--- a/airbrakes/simulation/sim_imu.py
+++ b/airbrakes/simulation/sim_imu.py
@@ -60,7 +60,7 @@ class SimIMU(BaseIMU):
         data_fetch_process = multiprocessing.Process(
             target=self._fetch_data_loop,
             name="Sim IMU Process",
-            args=(config,),
+            args=(config, real_time_replay),
         )
 
         super().__init__(data_fetch_process, data_queue)
@@ -79,7 +79,7 @@ class SimIMU(BaseIMU):
             ServoExtension.MAX_NO_BUZZ,
         )
 
-    def _fetch_data_loop(self, config: SimulationConfig) -> None:
+    def _fetch_data_loop(self, config: SimulationConfig, real_time_replay: bool) -> None:
         """A wrapper function to suppress KeyboardInterrupt exceptions when obtaining generated
         data."""
 
@@ -110,4 +110,6 @@ class SimIMU(BaseIMU):
                 time_step = update_timestamp(timestamp, config) - timestamp
                 timestamp += time_step
                 end_time = time.time()
-                time.sleep(max(0.0, time_step - (end_time - start_time)))
+
+                if real_time_replay:
+                    time.sleep(max(0.0, time_step - (end_time - start_time)))

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -76,81 +76,31 @@ def deadband(input_value: float, threshold: float) -> float:
     return input_value
 
 
-def arg_parser(mock_invocation: bool = False, sim_invocation: bool = False) -> argparse.Namespace:
+def arg_parser() -> argparse.Namespace:
     """Handles the command line arguments for the main airbrakes script.
-
-    :param mock_invocation: Whether the application is running in mock mode from `uv run mock`.
-    Defaults to False, to keep compatibility with the `python -m airbrakes.main` invocation method.
-    :param sim_invocation: Whether the application is running in sim mode from `uv run sim`.
-    Defaults to False, to keep compatibility with the `python -m airbrakes.main` invocation method.
 
     :return: The parsed arguments as a class with attributes.
     """
+    # We require ONE and only one of the 3 positional arguments to be passed:
+    # - real: Run the real flight with all the real hardware.
+    # - mock: Run in replay mode with mock data and mock servo.
+    # - sim: Runs the data simulation alongside the mock simulation, with an optional scale.
+    global_parser = argparse.ArgumentParser(add_help=False)
 
-    parser = argparse.ArgumentParser(
-        description="Configuration for the main airbrakes script. "
-        "No arguments should be supplied when you are actually launching the rocket."
-    )
+    # Global mutually exclusive group, for the `--debug` and `--verbose` options:
+    global_group = global_parser.add_mutually_exclusive_group()
 
-    parser.add_argument(
-        "-m",
-        "--mock",
-        help="Run in replay mode with mock data and mock servo",
-        action="store_true",
-        default=mock_invocation,
-    )
-
-    parser.add_argument(
-        "-r",
-        "--real-servo",
-        help="Run the mock replay with the real servo",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
-        "-l",
-        "--keep-log-file",
-        help="Keep the log file after the mock replay stops",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
-        "-f",
-        "--fast-replay",
-        help="Run the mock replay at full speed instead of in real time.",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
+    # These are global options, available to `mock`, `real`, and `sim` modes:
+    global_group.add_argument(
         "-d",
         "--debug",
-        help="Run the mock replay in debug mode. This will not "
+        help="Run the flight without a display. This will not "
         "print the flight data and allow you to inspect the values of your print() statements.",
         action="store_true",
         default=False,
     )
 
-    parser.add_argument(
-        "-c",
-        "--real-camera",
-        help="Run the mock replay with the real camera.",
-        action="store_true",
-        default=False,
-    )
-
-    parser.add_argument(
-        "-p",
-        "--path",
-        help="Define the pathname of flight data to use in mock replay. Interest Launch data"
-        " is used by default",
-        type=Path,
-        default=None,
-    )
-
-    parser.add_argument(
+    global_group.add_argument(
         "-v",
         "--verbose",
         help="Shows the display with much more data.",
@@ -158,43 +108,102 @@ def arg_parser(mock_invocation: bool = False, sim_invocation: bool = False) -> a
         default=False,
     )
 
-    if sim_invocation:
+    # Top-level parser for the main script:
+    main_parser = argparse.ArgumentParser(
+        description="Main parser for the airbrakes script.",
+        parents=[global_parser],
+    )
+
+    # Subparsers for `real`, `mock`, and `sim`
+    subparsers = main_parser.add_subparsers(
+        title="modes", description="Valid modes of operation", dest="mode", required=True
+    )
+
+    # Real flight parser:
+    subparsers.add_parser(
+        "real",
+        help="Run the real flight with all the real hardware.",
+        description="Configuration for the real flight.",
+        parents=[global_parser],  # Include the global options
+        prog="real",  # Program name in help messages
+    )
+    # No extra arguments needed for the real flight mode.
+
+    # Mock replay parser:
+    mock_replay_parser = subparsers.add_parser(
+        "mock",
+        help="Run in replay mode with mock data (i.e. previous flight data)",
+        description="Configuration for the mock replay airbrakes script.",
+        parents=[global_parser],  # Include the global options
+        prog="mock",  # Program name in help messages
+    )
+    add_common_arguments(mock_replay_parser, is_mock=True)
+
+    # Sim parser
+    sim_parser = subparsers.add_parser(
+        "sim",
+        help="Runs the data simulation alongside the mock simulation.",
+        description="Configuration for the data simulation alongside the mock simulation.",
+        parents=[global_parser],  # Include the global options
+        prog="sim",  # Program name in help messages
+    )
+
+    sim_parser.add_argument(
+        "scale",
+        help="Simulation scale.",
+        choices=["full-scale", "sub-scale", "legacy"],
+        nargs="?",  # Optional
+        default="full-scale",
+    )
+
+    add_common_arguments(sim_parser, is_mock=False)
+
+    return main_parser.parse_args()
+
+
+def add_common_arguments(parser: argparse.ArgumentParser, is_mock: bool = True) -> None:
+    """Adds the arguments common to the mock replay and the sim to the parser."""
+
+    _type = "mock replay" if is_mock else "sim"
+
+    parser.add_argument(
+        "-r",
+        "--real-servo",
+        help=f"Run the {_type} with the real servo",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "-l",
+        "--keep-log-file",
+        help=f"Keep the log file after the {_type} stops",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "-f",
+        "--fast-replay",
+        help=f"Run the {_type} at full speed instead of in real time.",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "-c",
+        "--real-camera",
+        help=f"Run the {_type} with the real camera.",
+        action="store_true",
+        default=False,
+    )
+
+    if is_mock:
         parser.add_argument(
-            "sim",
-            help="Runs the data simulation alongside the mock simulation, with an optional scale",
-            choices=["full-scale", "sub-scale", "legacy"],
-            nargs="?",  # Allows an optional argument
-            default="full-scale",  # Default when `-s` is provided without a value
+            "-p",
+            "--path",
+            help="Define the pathname of flight data to use in mock replay. By default, the"
+            " first file found in the launch_data directory will be used if not specified.",
+            type=Path,
+            default=None,
         )
-
-    args = parser.parse_args()
-
-    if not hasattr(args, "sim"):
-        args.sim = False
-
-    # Check if the user has passed any options that are only available in mock replay mode:
-    if (
-        any(
-            [
-                args.real_servo,
-                args.keep_log_file,
-                args.fast_replay,
-                args.path,
-                args.real_camera,
-                args.sim,
-            ]
-        )
-        and not args.mock
-    ):
-        parser.error(
-            "The `--real-servo`, `--keep-log-file`, `--fast-replay`, `sim`, and `--path` "
-            "options are only available in mock replay mode. Please pass `-m` or `--mock` "
-            "to run in mock replay mode."
-        )
-
-    if args.verbose and args.debug:
-        parser.error("The `--verbose` and `--debug` options cannot be used together.")
-
-    if args.sim and args.path:
-        parser.error("The `--path` option is not able to be used with the `sim` option")
-    return args

--- a/legacy_project_setup.md
+++ b/legacy_project_setup.md
@@ -43,19 +43,31 @@ Then, follow from [step 3 on the main README](README.md#3-install-the-pre-commit
 The python equivalent command to `uv` is:
 
 ```bash
-python -m airbrakes.main -m
+python -m airbrakes.main mock
 ``` 
 
 for running a mock. So to run a mock sim with the real servo, you would run:
 
 ```bash
-python -m airbrakes.main -m -r
+python -m airbrakes.main mock -r
 ```
 
 To run a real flight, you would run:
 
 ```bash
-python -m airbrakes.main
+python -m airbrakes.main real
+```
+
+To run a simulation, you would run:
+
+```bash
+python -m airbrakes.main sim
+```
+
+As always, you can see all the options by running:
+
+```bash
+python -m airbrakes.main --help
 ```
 
 To run a script for testing, you would run:
@@ -64,4 +76,4 @@ To run a script for testing, you would run:
 python scripts/run_logger.py
 ```
 
-_There are libraries that only fully work when running on the Pi (gpiozero, mscl), so if you're having trouble importing them locally, program the best you can and test your changes on the pi._
+_There are libraries that only fully work when running on the Pi (gpiozero, mscl, picamera2), so if you're having trouble importing them locally, program the best you can and test your changes on the pi._

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def mocked_args_parser():
     """Fixture that returns a mocked argument parser."""
 
     class MockArgs:
-        mock = True
+        mode = "mock"
         real_servo = False
         keep_log_file = False
         fast_replay = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,10 +11,17 @@ from airbrakes.constants import LOGS_PATH
 from airbrakes.hardware.camera import Camera
 from airbrakes.hardware.imu import IMU
 from airbrakes.hardware.servo import Servo
-from airbrakes.main import create_components, run_flight, run_mock_flight, run_real_flight
+from airbrakes.main import (
+    create_components,
+    run_flight,
+    run_mock_flight,
+    run_real_flight,
+    run_sim_flight,
+)
 from airbrakes.mock.mock_camera import MockCamera
 from airbrakes.mock.mock_imu import MockIMU
 from airbrakes.mock.mock_logger import MockLogger
+from airbrakes.simulation.sim_imu import SimIMU
 from airbrakes.telemetry.apogee_predictor import ApogeePredictor
 from airbrakes.telemetry.data_processor import IMUDataProcessor
 from airbrakes.telemetry.logger import Logger
@@ -43,22 +50,31 @@ def parsed_args(request, monkeypatch):
 @pytest.mark.parametrize(
     "parsed_args",
     [
-        (["main.py"]),
-        (["main.py", "--mock"]),
-        (["main.py", "-m", "-r"]),
-        (["main.py", "-m", "-r", "-c"]),
-        (["main.py", "-m", "-r", "-c", "-l"]),
-        (["main.py", "-m", "-r", "-c", "-l", "-f"]),
-        (["main.py", "-m", "-r", "-c", "-l", "-f", "-p", "launch_data/something"]),
+        (["main.py", "real"]),
+        (["main.py", "mock"]),
+        (["main.py", "mock", "-r"]),
+        (["main.py", "mock", "-r", "-c"]),
+        (["main.py", "mock", "-r", "-c", "-l"]),
+        (["main.py", "mock", "-r", "-c", "-l", "-f"]),
+        (["main.py", "mock", "-r", "-c", "-l", "-f", "-p", "launch_data/something"]),
+        (
+            [
+                "main.py",
+                "sim",
+                "sub-scale",
+                "-r",
+            ]
+        ),
     ],
     ids=[
-        "no-args",
+        "real flight",
         "mock",
         "mock with real servo",
         "mock with real servo and camera",
         "mock with real servo, camera and log file kept",
         "mock with real servo, camera, log file kept and fast replay",
         "mock with real servo, camera, log file kept, fast replay and specific launch file",
+        "sim with real servo",
     ],
     indirect=True,
 )
@@ -74,38 +90,54 @@ def test_create_components(parsed_args, monkeypatch):
     assert isinstance(created_components[-1], ApogeePredictor)
     assert isinstance(created_components[-2], IMUDataProcessor)
 
-    if parsed_args.mock:
-        assert isinstance(created_components[1], MockIMU)
+    if parsed_args.mode in ("mock", "sim"):
+        if parsed_args.mode == "mock":
+            assert type(created_components[1]) is MockIMU
+
+            if parsed_args.path:
+                assert created_components[1]._log_file_path == parsed_args.path
+            else:
+                # First file in the launch_data directory:
+                assert "launch_data" in str(created_components[1]._log_file_path)
+
+        else:  # sim
+            assert type(created_components[1]) is SimIMU
+
         if parsed_args.fast_replay:
             assert not created_components[1]._data_fetch_process._args[1]
         else:
             assert created_components[1]._data_fetch_process._args[1]
 
-        if parsed_args.path:
-            assert created_components[1]._log_file_path == parsed_args.path
-        else:
-            # First file in the launch_data directory:
-            assert "launch_data" in str(created_components[1]._log_file_path)
-
         # check if the real camera is created:
         if parsed_args.real_camera:
-            assert isinstance(created_components[2], Camera)
+            assert type(created_components[2]) is Camera
         else:
-            assert isinstance(created_components[2], MockCamera)
-    else:
-        assert isinstance(created_components[1], IMU)
+            assert type(created_components[2]) is MockCamera
 
-    if parsed_args.real_servo:
-        assert isinstance(created_components[0], Servo)
-    else:
-        assert isinstance(created_components[0], Servo)
-        assert isinstance(created_components[0].servo.pin_factory, gpiozero.pins.mock.MockFactory)
+        # This particular test case is bad, I'm not testing whether our pin factory is PiGPIO or not
+        # since I don't want to run the constructor of that class, which errors out.
+        # TODO: Use a magic mock?
+        if parsed_args.real_servo:
+            assert type(created_components[0]) is Servo
+        else:
+            assert type(created_components[0]) is Servo
+            assert isinstance(
+                created_components[0].servo.pin_factory, gpiozero.pins.mock.MockFactory
+            )
 
-    if parsed_args.keep_log_file:
-        assert isinstance(created_components[3], MockLogger)
-        assert created_components[3].delete_log_file is False
+        # A mock logger object is always created:
+        assert type(created_components[3]) is MockLogger
+        if parsed_args.keep_log_file:
+            assert created_components[3].delete_log_file is False
+        else:
+            assert created_components[3].delete_log_file is True
+
+    # Real hardware components:
     else:
-        assert isinstance(created_components[3], Logger)
+        assert type(created_components[1]) is IMU
+        assert type(created_components[0]) is Servo
+        assert type(created_components[2]) is Camera
+        assert type(created_components[3]) is Logger
 
 
 def test_run_real_flight(monkeypatch):
@@ -127,10 +159,12 @@ def test_run_real_flight(monkeypatch):
     run_real_flight()
 
     assert len(calls) == 2
-    # i.e. test that we didn't pass mock_invocation=True to arg_parser:
+    # i.e. test that we didn't pass any arguments to the arg_parser:
     assert not arg_parser_arguments
     # test that we called the arg parser and the run_flight functions
     assert calls == ["parsed arguments", "run_flight"]
+    # Test that we modified sys.argv to include "real":
+    assert sys.argv[1] == "real"
 
 
 def test_run_mock_flight(monkeypatch):
@@ -152,10 +186,39 @@ def test_run_mock_flight(monkeypatch):
     run_mock_flight()
 
     assert len(calls) == 2
-    # i.e. test that we passed mock_invocation=True to arg_parser:
-    assert arg_parser_kwargs == {"mock_invocation": True}
+    # i.e. test that we passed no arguments to the arg_parser:
+    assert not arg_parser_kwargs
     # test that we called the arg parser and the run_flight functions
     assert calls == ["parsed arguments", "run_flight"]
+    # Test that we modified sys.argv to include "mock":
+    assert sys.argv[1] == "mock"
+
+
+def test_run_sim_flight(monkeypatch):
+    """Tests the run_sim_flight function."""
+    arg_parser_kwargs = []
+    calls = []
+
+    def mock_arg_parser(*args, **kwargs):
+        nonlocal arg_parser_kwargs, calls
+        arg_parser_kwargs = kwargs
+        calls.append("parsed arguments")
+
+    def patched_run_flight(*args, **kwargs):
+        calls.append("run_flight")
+
+    monkeypatch.setattr("airbrakes.main.arg_parser", mock_arg_parser)
+    monkeypatch.setattr("airbrakes.main.run_flight", patched_run_flight)
+
+    run_sim_flight()
+
+    assert len(calls) == 2
+    # i.e. test that we passed no arguments to the arg_parser:
+    assert not arg_parser_kwargs
+    # test that we called the arg parser and the run_flight functions
+    assert calls == ["parsed arguments", "run_flight"]
+    # Test that we modified sys.argv to include "sim":
+    assert sys.argv[1] == "sim"
 
 
 def test_run_flight(monkeypatch, mocked_args_parser):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,96 +53,177 @@ def test_deadband():
 class TestArgumentParsing:
     """Tests for the argument parsing function (arg_parser())."""
 
-    def test_init(self, monkeypatch):
-        """Tests the default values of the argument parser."""
-
-        # Mock sys.argv to simulate no arguments being passed to the script
+    def test_default_invocation(self, monkeypatch):
+        """Tests that running the script without arguments results in an error."""
         monkeypatch.setattr(sys, "argv", ["main.py"])
 
+        with pytest.raises(SystemExit):
+            arg_parser()
+
+    def test_real_mode(self, monkeypatch):
+        """Tests the 'real' mode arguments."""
+        monkeypatch.setattr(sys, "argv", ["main.py", "real", "-v"])
+
         args = arg_parser()
-        assert args.__dict__ == {
-            "mock": False,
-            "real_servo": False,
-            "keep_log_file": False,
-            "fast_replay": False,
-            "debug": False,
-            "path": None,
-            "verbose": False,
-            "real_camera": False,
-            "sim": False,
+        # This is to ensure that all the arguments are correctly parsed, and to make sure that
+        # if you make a change, you update the test.
+        assert len(args.__dict__) == 3
+        assert args.__dict__.keys() == {"mode", "verbose", "debug"}
+        assert args.mode == "real"
+        assert args.verbose is True
+        assert args.debug is False
+
+    def test_mock_mode(self, monkeypatch):
+        """Tests the 'mock' mode arguments."""
+        monkeypatch.setattr(
+            sys, "argv", ["main.py", "mock", "-r", "-l", "-f", "-c", "-p", "mock/data/path"]
+        )
+
+        args = arg_parser()
+        # This is to ensure that all the arguments are correctly parsed, and to make sure that
+        # if you make a change, you update the test.
+        assert len(args.__dict__) == 8
+        assert args.__dict__.keys() == {
+            "mode",
+            "real_servo",
+            "keep_log_file",
+            "fast_replay",
+            "real_camera",
+            "path",
+            "verbose",
+            "debug",
+        }
+        assert args.mode == "mock"
+        assert args.real_servo is True
+        assert args.keep_log_file is True
+        assert args.fast_replay is True
+        assert args.real_camera is True
+        assert args.path == Path("mock/data/path")
+        assert args.verbose is False
+        assert args.debug is False
+
+    def test_sim_mode(self, monkeypatch):
+        """Tests the 'sim' mode arguments."""
+        monkeypatch.setattr(sys, "argv", ["main.py", "sim", "sub-scale", "-r", "-l", "-f", "-c"])
+
+        args = arg_parser()
+        # This is to ensure that all the arguments are correctly parsed, and to make sure that
+        # if you make a change, you update the test.
+        assert len(args.__dict__) == 8
+        assert args.__dict__.keys() == {
+            "mode",
+            "scale",
+            "real_servo",
+            "keep_log_file",
+            "fast_replay",
+            "real_camera",
+            "verbose",
+            "debug",
         }
 
+        assert args.mode == "sim"
+        assert args.scale == "sub-scale"
+        assert args.real_servo is True
+        assert args.keep_log_file is True
+        assert args.fast_replay is True
+        assert args.real_camera is True
+        assert not hasattr(args, "path")  # `--path` should not be available in `sim` mode
+
+    def test_verbose_and_debug_exclusivity(self, monkeypatch, capsys):
+        """Tests that the `-v` and `-d` flags are mutually exclusive."""
+        monkeypatch.setattr(sys, "argv", ["main.py", "real", "-v", "-d"])
+
+        with pytest.raises(SystemExit):
+            arg_parser()
+
+        captured = capsys.readouterr()
+        assert "not allowed with argument" in captured.err
+
     @pytest.mark.parametrize(
-        "mock_invocation",
-        [True, False],
-        ids=["uv-method", "legacy-method"],
+        ("mode", "args"),
+        [
+            ("real", ["-r"]),
+            ("real", ["-l"]),
+            ("real", ["-f"]),
+            ("real", ["-c"]),
+            ("real", ["-p", "path/to/log"]),
+        ],
+        ids=[
+            "real_with_real_servo",
+            "real_with_keep_log",
+            "real_with_fast_replay",
+            "real_with_real_camera",
+            "real_with_path",
+        ],
     )
-    def test_mock_invocation(self, monkeypatch, mock_invocation):
-        """Tests the mock invocation of the script."""
+    def test_invalid_args_in_real_mode(self, monkeypatch, mode, args, capsys):
+        """Tests that 'real' mode does not accept arguments meant for 'mock' or 'sim'."""
+        monkeypatch.setattr(sys, "argv", ["main.py", mode, *args])
 
-        # Mock sys.argv to simulate the script being run in mock mode
-        monkeypatch.setattr(sys, "argv", ["main.py", "-m"])
+        with pytest.raises(SystemExit):
+            arg_parser()
 
-        args = arg_parser(mock_invocation=mock_invocation)
-        assert args.mock is True
-        assert args.real_servo is False
-        assert args.keep_log_file is False
-        assert args.fast_replay is False
-        assert args.debug is False
-        assert args.path is None
-        assert args.verbose is False
-        assert args.real_camera is False
-        assert args.sim is False
+        captured = capsys.readouterr()
+        assert "unrecognized arguments" in captured.err
 
-    def test_path_argument(self, monkeypatch):
-        """Tests the path argument of the script."""
-
-        # Mock sys.argv to simulate the script being run with the path argument
-        monkeypatch.setattr(sys, "argv", ["main.py", "-m", "-p", "path/to/log"])
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["mock", "-p", "mock/data/path"],
+            ["sim", "-r", "-l", "-f", "-c"],
+            ["sim", "legacy", "-r"],
+        ],
+        ids=["mock_with_path", "sim_with_common_args", "sim_with_scale_and_common_args"],
+    )
+    def test_shared_arguments(self, monkeypatch, args):
+        """Tests that shared arguments are correctly parsed across 'mock' and 'sim'."""
+        monkeypatch.setattr(sys, "argv", ["main.py", *args])
 
         args = arg_parser()
-        assert args.mock is True
-        assert args.real_servo is False
-        assert args.keep_log_file is False
-        assert args.fast_replay is False
-        assert args.debug is False
-        assert isinstance(args.path, Path)
-        assert args.path == Path("path/to/log")
-        assert args.verbose is False
-        assert args.sim is False
+        if "mock" in args.mode:
+            assert args.path == Path("mock/data/path")
+        elif "sim" in args.mode:
+            assert args.scale
+            assert not hasattr(args, "path")
+            if args.scale == "legacy":
+                assert args.real_servo is True
+                assert args.keep_log_file is False
+                assert args.fast_replay is False
+                assert args.real_camera is False
+            else:
+                assert args.real_servo is True
+                assert args.keep_log_file is True
+                assert args.fast_replay is True
+                assert args.real_camera is True
 
-    def test_mutually_exclusive_verbose_and_debug(self, monkeypatch, capsys):
-        """Tests that the verbose and debug flags are mutually exclusive."""
+    def test_sim_default_scale(self, monkeypatch):
+        """Tests that the 'sim' mode defaults to 'full-scale' if no scale is provided."""
+        monkeypatch.setattr(sys, "argv", ["main.py", "sim"])
 
-        # Mock sys.argv to simulate the script being run with both verbose and debug flags
-        monkeypatch.setattr(sys, "argv", ["main.py", "-v", "-d"])
+        args = arg_parser()
+        assert args.mode == "sim"
+        assert args.scale == "full-scale"
 
-        with pytest.raises(SystemExit):
-            arg_parser()
-
-        captured = capsys.readouterr()
-        assert "options cannot be used together" in captured.err
-
-    @pytest.mark.parametrize(
-        "arg_type",
-        [
-            ["--real-servo"],
-            ["--keep-log-file"],
-            ["--fast-replay"],
-            ["--path", "a/path"],
-            ["--real-camera"],
-        ],
-        ids=["real_servo", "keep_log_file", "fast_replay", "path", "real_camera"],
-    )
-    def test_args_only_available_with_mock_invocation(self, monkeypatch, capsys, arg_type):
-        """Tests that the arguments that are only available in mock replay mode are not available
-        in real mode."""
-
-        # Mock sys.argv to simulate the script being run with the real servo flag
-        monkeypatch.setattr(sys, "argv", ["main.py", *arg_type])
+    def test_help_output(self, monkeypatch, capsys):
+        """Tests that help output includes global and subparser-specific arguments."""
+        monkeypatch.setattr(sys, "argv", ["main.py", "mock", "-h"])
 
         with pytest.raises(SystemExit):
             arg_parser()
 
         captured = capsys.readouterr()
-        assert "only available in mock replay mode" in captured.err
+        assert "-v, --verbose" in captured.out
+        assert "-d, --debug" in captured.out
+        assert "--real-servo" in captured.out
+        assert "--path" in captured.out
+
+        monkeypatch.setattr(sys, "argv", ["main.py", "sim", "-h"])
+
+        with pytest.raises(SystemExit):
+            arg_parser()
+
+        captured = capsys.readouterr()
+        assert "-v, --verbose" in captured.out
+        assert "-d, --debug" in captured.out
+        assert "--real-servo" in captured.out
+        assert "--path" not in captured.out  # `--path` should not be in `sim` help


### PR DESCRIPTION
Refactors argument parsing to be more concise, explicit, and error free.

1. Unifies the legacy way of starting the script and the `uv` way.
2. Uses built-in mechanism for mutually exclusive arguments
3. Splits the argument parsing into 3 separate subparsers.
4. Better and more exhaustive tests
5. Makes SimIMU work with `-f`.

Merge after legacy launch. Or before (but then I would have to rebase)
