### PR TITLE
Meticulous Refining of Comments & Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ AirbrakesV2/
 │   │   ├── [files related to our custom air brakes sim ...]
 |   ├── telemetry/
 │   │   ├── [files related to the processing of data ...]
-│   ├── [files which control the airbrakes at a high level ...]
+│   ├── [files which control the air brakes at a high level ...]
 |   ├── main.py [main file used to run on the rocket]
 |   ├── constants.py [file for constants used in the project]
 ├── tests/  [used for testing all the code]

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 class AirbrakesContext:
     """
-    Manages the state machine for the rocket's airbrakes system, keeping track of the current state
+    Manages the state machine for the rocket's air brakes system, keeping track of the current state
     and communicating with hardware like the servo and IMU. This class is what connects the state
     machine to the hardware.
 
@@ -61,10 +61,10 @@ class AirbrakesContext:
         apogee_predictor: ApogeePredictor,
     ) -> None:
         """
-        Initializes the airbrakes context with the specified hardware objects, logger, and data
+        Initializes the Airbrakes Context with the specified hardware objects, logger, and data
         processor. The state machine starts in the StandbyState, which is the initial state of the
-        airbrakes system.
-        :param servo: The servo object that controls the extension of the airbrakes. This can be a
+        air brakes system.
+        :param servo: The servo object that controls the extension of the air brakes. This can be a
         real servo or a mock servo.
         :param imu: The IMU object that reads data from the rocket's IMU. This can be a real IMU or
         a mock IMU.
@@ -104,8 +104,8 @@ class AirbrakesContext:
 
     def stop(self) -> None:
         """
-        Handles shutting down the airbrakes. This will cause the main loop to break. It retracts
-        the airbrakes, stops the IMU, and stops the logger.
+        Handles shutting down the air brakes. This will cause the main loop to break. It retracts
+        the air brakes, stops the IMU, and stops the logger.
         """
         if self.shutdown_requested:
             return
@@ -119,7 +119,7 @@ class AirbrakesContext:
     def update(self) -> None:
         """
         Called every loop iteration from the main process. Depending on the current state, it will
-        do different things. It is what controls the airbrakes and chooses when to move to the next
+        do different things. It is what controls the air brakes and chooses when to move to the next
         state.
         """
         # get_imu_data_packets() gets from the "first" item in the queue, i.e, the set of data
@@ -158,7 +158,7 @@ class AirbrakesContext:
         # Update the state machine based on the latest processed data
         self.state.update()
 
-        # Create packets representing the current state of the airbrakes system:
+        # Create packets representing the current state of the air brakes system:
         self.generate_data_packets()
 
         # Logs the current state, extension, IMU data, and processed data
@@ -175,20 +175,20 @@ class AirbrakesContext:
 
     def extend_airbrakes(self) -> None:
         """
-        Extends the airbrakes to the maximum extension.
+        Extends the air brakes to the maximum extension.
         """
         self.servo.set_extended()
 
     def retract_airbrakes(self) -> None:
         """
-        Retracts the airbrakes to the minimum extension.
+        Retracts the air brakes to the minimum extension.
         """
         self.servo.set_retracted()
 
     def predict_apogee(self) -> None:
         """
         Predicts the apogee of the rocket based on the current processed data. This
-        should only be called in the coast state, before we start controlling the airbrakes.
+        should only be called in the coast state, before we start controlling the air brakes.
         """
         # We have to only run this for estimated data packets, otherwise we send duplicate
         # data to the predictor (because for a raw data packet, we still have the 'old'
@@ -201,7 +201,7 @@ class AirbrakesContext:
         """
         Generates the context data packet and servo data packet to be logged.
         """
-        # Create a context data packet to log the current state of the airbrakes system
+        # Create a context data packet to log the current state of the air brakes system
         self.context_data_packet = ContextDataPacket(
             batch_number=self._update_count,
             state_letter=self.state.name[0],

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -1,4 +1,4 @@
-"""Contains the constants used in the airbrakes module"""
+"""Contains the constants used in the Airbrakes module"""
 
 from enum import Enum, StrEnum
 from pathlib import Path

--- a/airbrakes/main.py
+++ b/airbrakes/main.py
@@ -52,10 +52,14 @@ def run_sim_flight() -> None:
 
 
 def run_flight(args: argparse.Namespace) -> None:
+    """
+    Initializes the Airbrakes components and starts the main loop.
+    :param args: Command line arguments determining the program configuration.
+    """
     mock_time_start = time.time()
 
     servo, imu, camera, logger, data_processor, apogee_predictor = create_components(args)
-    # Initialize the airbrakes context and display
+    # Initialize the Airbrakes Context and display
     airbrakes = AirbrakesContext(servo, imu, camera, logger, data_processor, apogee_predictor)
     flight_display = FlightDisplay(airbrakes, mock_time_start, args)
 
@@ -67,10 +71,11 @@ def create_components(
     args: argparse.Namespace,
 ) -> tuple[Servo, BaseIMU, Camera, Logger, IMUDataProcessor, ApogeePredictor]:
     """
-    Creates the system components needed for the airbrakes system. Depending on its arguments, it
-    will return either mock or real components.
-    :param args: Command line arguments determining the configuration.
-    :return: A tuple containing the servo, IMU, Logger, data processor, and apogee predictor objects
+    Creates the system components needed for the air brakes system. Depending on its arguments, it
+        will return either mock, sim, or real components.
+    :param args: Command line arguments determining the program configuration.
+    :return: A tuple containing the Servo, IMU, Camera, Logger, IMUDataProcessor, and
+        ApogeePredictor objects.
     """
     if args.mode in ("mock", "sim"):
         if args.mode == "mock":
@@ -81,7 +86,7 @@ def create_components(
             )
         else:
             # Use simulation IMU
-            imu = SimIMU(sim_type=args.scale, real_time_replay=not args.fast_replay)
+            imu = SimIMU(sim_type=args.preset, real_time_replay=not args.fast_replay)
 
         # If using a real servo, use the real servo object, otherwise use a mock servo object
         servo = (
@@ -90,7 +95,7 @@ def create_components(
             else Servo(SERVO_PIN, pin_factory=MockFactory(pin_class=MockPWMPin))
         )
         logger = MockLogger(LOGS_PATH, delete_log_file=not args.keep_log_file)
-        camera = MockCamera() if not args.real_camera else Camera()
+        camera = Camera() if args.real_camera else MockCamera()
 
     else:
         # Use real hardware components
@@ -99,7 +104,9 @@ def create_components(
         logger = Logger(LOGS_PATH)
         camera = Camera()
 
-    # Initialize data processing and prediction
+    # the mock replay, simulation, and real Airbrakes program configuration will all
+    # use the IMUDataProcessor class and the ApogeePredictor class. There are no mock versions of
+    # these classes.
     data_processor = IMUDataProcessor()
     apogee_predictor = ApogeePredictor()
     return servo, imu, camera, logger, data_processor, apogee_predictor
@@ -113,12 +120,13 @@ def run_flight_loop(
 ) -> None:
     """
     Main flight control loop that runs until shutdown is requested or interrupted.
-    :param airbrakes: The airbrakes context managing the state machine.
+    :param airbrakes: The Airbrakes Context managing the state machine.
     :param flight_display: Display interface for flight data.
     :param is_mock: Whether running in mock replay mode.
+    :param is_sim: Whether running in simulation mode.
     """
     try:
-        # Starts the airbrakes system and display
+        # Starts the air brakes system and display
         airbrakes.start()
         flight_display.start()
 
@@ -129,20 +137,22 @@ def run_flight_loop(
             # Stop the replay when the data is exhausted
             if is_mock and not airbrakes.imu.is_running:
                 break
+            # This allows the simulation to know whether air brakes are deployed or not, and
+            # change the drag coefficient and reference area used
             if is_sim:
-                # Janky way to extend airbrakes in the sim and change the drag
                 airbrakes.imu.set_airbrakes_status(airbrakes.servo.current_extension)
 
     # Handle user interrupt gracefully
     except KeyboardInterrupt:
         if is_mock:
             flight_display.end_mock_interrupted.set()
-    else:  # This is run if we have landed and the program is not interrupted (see state.py)
+    else:
+        # This is run if we have landed, the landed buffer is reached, and the program is not
+        # interrupted (see state.py)
         if is_mock:
-            # Stop the mock replay naturally if not interrupted
             flight_display.end_mock_natural.set()
     finally:
-        # Stop the display and airbrakes
+        # Stops the display and the Airbrakes program
         flight_display.stop()
         airbrakes.stop()
 
@@ -156,9 +166,12 @@ if __name__ == "__main__":
     # python -m airbrakes.main mock: Runs a mock replay on your computer
     # python -m airbrakes.main mock -r: Runs a mock replay on your computer with the real servo
     # python -m airbrakes.main mock -l: Runs a mock replay on your computer and keeps the log file
-    # after the mock replay stops
+    #   after the mock replay stops
     # python -m airbrakes.main mock -f: Runs a mock replay on your computer at full speed
     # python -m airbrakes.main mock -d: Runs a mock replay on your computer in debug
-    # mode (w/o display)
+    #   mode (w/o display)
+    # python -m airbrakes.main mock -c: Runs a mock replay on your computer with the real camera
+    # python -m airbrakes.main mock -p [path]: Runs a mock replay on your computer using the
+    #   launch data at the path specified after -p
     args = arg_parser()
     run_flight(args)

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -1,4 +1,4 @@
-"""Module for the finite state machine that represents which state of flight we are in."""
+"""Module for the finite state machine that represents which state of flight the rocket is in."""
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
@@ -11,7 +11,7 @@ from airbrakes.constants import (
     TAKEOFF_VELOCITY_METERS_PER_SECOND,
     TARGET_ALTITUDE_METERS,
 )
-from airbrakes.utils import convert_to_seconds
+
 
 if TYPE_CHECKING:
     from airbrakes.airbrakes import AirbrakesContext
@@ -19,29 +19,31 @@ if TYPE_CHECKING:
 
 class State(ABC):
     """
-    Abstract Base class for the states of the airbrakes system. Each state will have an update
+    Abstract Base class for the states of the air brakes system. Each state will have an update
     method that will be called every loop iteration and a next_state method that will be called
     when the state is over.
 
-    For Airbrakes, we will have 4 states:
-    1. Stand By - when the rocket is on the rail on the ground
+    For Airbrakes, we will have 5 states:
+    1. Standby - when the rocket is on the rail on the ground
     2. Motor Burn - when the motor is burning and the rocket is accelerating
-    3. Flight - when the motor has burned out and the rocket is coasting, this is when air brakes
-        will be deployed.
+    3. Coast - after the motor has burned out and the rocket is coasting, this is when air brakes
+        deployment will be controlled by the bang-bang controller.
     4. Free Fall - when the rocket is falling back to the ground after apogee, this is when the air
         brakes will be retracted.
+    5. Landed - when the rocket lands on the ground. After a few seconds in landed state, the
+        Airbrakes program will end.
     """
 
-    __slots__ = ("context", "start_time_ns")
+    __slots__ = ("airbrakes", "start_time_ns")
 
-    def __init__(self, context: "AirbrakesContext"):
+    def __init__(self, airbrakes: "AirbrakesContext"):
         """
-        :param context: The state context object that will be used to interact with the electronics
+        :param airbrakes: The Airbrakes Context managing the state machine.
         """
-        self.context = context
-        # At the very beginning of each state, we retract the airbrakes
-        self.context.retract_airbrakes()
-        self.start_time_ns = context.data_processor.current_timestamp
+        self.airbrakes = airbrakes
+        # At the very beginning of each state, we retract the air brakes
+        self.airbrakes.retract_airbrakes()
+        self.start_time_ns = airbrakes.data_processor.current_timestamp
 
     @property
     def name(self):
@@ -53,8 +55,8 @@ class State(ABC):
     @abstractmethod
     def update(self):
         """
-        Called every loop iteration. Uses the context to interact with the hardware and decides
-        when to move to the next state.
+        Called every loop iteration. Uses the Airbrakes Context to interact with the hardware and
+        decides when to move to the next state.
         """
 
     @abstractmethod
@@ -67,28 +69,24 @@ class State(ABC):
 
 class StandbyState(State):
     """
-    When the rocket is on the rail on the ground.
+    When the rocket is on the launch rail on the ground.
     """
 
     __slots__ = ()
 
     def update(self):
         """
-        Checks if the rocket has launched, based on our velocity and altitude.
+        Checks if the rocket has launched, based on our velocity.
         """
-        # We need to check if the rocket has launched, if it has, we move to the next state.
-        # For that we can check:
-        # 1) Velocity - If the velocity of the rocket is above a threshold, the rocket has
-        # launched.
 
-        data = self.context.data_processor
-
+        data = self.airbrakes.data_processor
+        # If the velocity of the rocket is above a threshold, the rocket has launched.
         if data.vertical_velocity > TAKEOFF_VELOCITY_METERS_PER_SECOND:
             self.next_state()
             return
 
     def next_state(self):
-        self.context.state = MotorBurnState(self.context)
+        self.airbrakes.state = MotorBurnState(self.airbrakes)
 
 
 class MotorBurnState(State):
@@ -98,15 +96,15 @@ class MotorBurnState(State):
 
     __slots__ = ()
 
-    def __init__(self, context: "AirbrakesContext"):
-        super().__init__(context)
-        self.context.camera.start_recording()
+    def __init__(self, airbrakes: "AirbrakesContext"):
+        super().__init__(airbrakes)
+        self.airbrakes.camera.start_recording()
 
     def update(self):
-        """Checks to see if the acceleration has dropped to zero, indicating the motor has
-        burned out."""
+        """Checks to see if the velocity has decreased lower than the maximum velocity, indicating
+        the motor has burned out."""
 
-        data = self.context.data_processor
+        data = self.airbrakes.data_processor
 
         # If our current velocity is less than our max velocity, that means we have stopped
         # accelerating. This is the same thing as checking if our accel sign has flipped
@@ -117,44 +115,44 @@ class MotorBurnState(State):
             return
 
     def next_state(self):
-        self.context.state = CoastState(self.context)
+        self.airbrakes.state = CoastState(self.airbrakes)
 
 
 class CoastState(State):
     """
     When the motor has burned out and the rocket is coasting to apogee. This is the state
-    we actually extend the airbrakes.
+    we actually control the air brakes extension.
     """
 
     __slots__ = ("airbrakes_extended",)
 
-    def __init__(self, context: "AirbrakesContext"):
-        super().__init__(context)
+    def __init__(self, airbrakes: "AirbrakesContext"):
+        super().__init__(airbrakes)
         self.airbrakes_extended = False
 
     def update(self):
         """Checks to see if the rocket has reached apogee, indicating the start of free fall."""
 
         # In Coast State we start predicting the apogee
-        self.context.predict_apogee()
+        self.airbrakes.predict_apogee()
 
-        data = self.context.data_processor
+        data = self.airbrakes.data_processor
 
-        # This is our bang-bang controller for the airbrakes. If we predict we are going to
-        # overshoot our target altitude, we extend the airbrakes. If we predict we are going to
-        # undershoot our target altitude, we retract the airbrakes.
+        # This is our bang-bang controller for the air brakes. If we predict we are going to
+        # overshoot our target altitude, we extend the air brakes. If we predict we are going to
+        # undershoot our target altitude, we retract the air brakes.
 
         # Gets the latest apogee prediction
-        apogee = self.context.last_apogee_predictor_packet.predicted_apogee
+        apogee = self.airbrakes.last_apogee_predictor_packet.predicted_apogee
 
         if apogee > TARGET_ALTITUDE_METERS and not self.airbrakes_extended:
-            self.context.extend_airbrakes()
+            self.airbrakes.extend_airbrakes()
             self.airbrakes_extended = True
         elif apogee <= TARGET_ALTITUDE_METERS and self.airbrakes_extended:
-            self.context.retract_airbrakes()
+            self.airbrakes.retract_airbrakes()
             self.airbrakes_extended = False
 
-        # if our velocity is close to zero or negative, we are in free fall.
+        # if our velocity is zero or negative, we are in free fall.
         if data.vertical_velocity <= 0:
             self.next_state()
             return
@@ -166,8 +164,7 @@ class CoastState(State):
             return
 
     def next_state(self):
-        # This also retracts the airbrakes:
-        self.context.state = FreeFallState(self.context)
+        self.airbrakes.state = FreeFallState(self.airbrakes)
 
 
 class FreeFallState(State):
@@ -178,9 +175,9 @@ class FreeFallState(State):
     __slots__ = ()
 
     def update(self):
-        """Check if the rocket has landed, based on our altitude."""
+        """Check if the rocket has landed, based on our altitude and a spike in acceleration."""
 
-        data = self.context.data_processor
+        data = self.airbrakes.data_processor
 
         # If our altitude is around 0, and we have an acceleration spike, we have landed
         if (
@@ -189,12 +186,13 @@ class FreeFallState(State):
         ):
             self.next_state()
 
-        # If we have been in free fall for too long, we move to the landed state
-        if convert_to_seconds(data.current_timestamp - self.start_time_ns) >= MAX_FREE_FALL_SECONDS:
+        # Sometimes the rocket can land and the alitude will be above the ground altitude threshold.
+        # This is a fallback condition so that we won't be stuck in freefall state.
+        if (data.current_timestamp - self.start_time_ns) * 1e-9 >= MAX_FREE_FALL_SECONDS:
             self.next_state()
 
     def next_state(self):
-        self.context.state = LandedState(self.context)
+        self.airbrakes.state = LandedState(self.airbrakes)
 
 
 class LandedState(State):
@@ -205,10 +203,10 @@ class LandedState(State):
     __slots__ = ()
 
     def update(self):
-        """We use this method to stop the airbrakes system after we have hit our log buffer."""
+        """We use this method to stop the air brakes system after we have hit our log buffer."""
 
-        if self.context.logger.is_log_buffer_full:
-            self.context.stop()
+        if self.airbrakes.logger.is_log_buffer_full:
+            self.airbrakes.stop()
 
     def next_state(self):
         # Explicitly do nothing, there is no next state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AirbrakesV2"
-description = "Logic for airbrakes as a part of the NASA Student Launch Competition"
+description = "Logic for air brakes as a part of the NASA Student Launch Competition"
 requires-python = ">=3.13"
 version = "1.1.0"
 readme = "README.md"

--- a/tests/test_airbrakes.py
+++ b/tests/test_airbrakes.py
@@ -146,9 +146,9 @@ class TestAirbrakesContext:
         def state(self):
             # monkeypatched method of State
             calls.append("state update called")
-            if isinstance(self.context.state, CoastState):
-                self.context.predict_apogee()
-                self.context.servo.current_extension = ServoExtension.MAX_EXTENSION
+            if isinstance(self.airbrakes.state, CoastState):
+                self.airbrakes.predict_apogee()
+                self.airbrakes.servo.current_extension = ServoExtension.MAX_EXTENSION
 
         def log(self, ctx_dp, servo_dp, imu_data_packets, processor_data_packets, apg_dps):
             # monkeypatched method of Logger

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,43 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from airbrakes.utils import arg_parser, convert_str_to_float, convert_to_nanoseconds, deadband
-
-
-@pytest.mark.parametrize(
-    ("input_value", "expected"),
-    [
-        ("1", 1),
-        ("0.5", 500_000_000),
-        ("invalid", None),
-    ],
-    ids=["string_int_input", "string_float_input", "invalid"],
-)
-def test_convert_to_nanoseconds_correct_inputs(input_value, expected):
-    assert convert_to_nanoseconds(input_value) == expected
-
-
-@pytest.mark.parametrize(
-    ("input_value", "expected"),
-    [
-        (1, 1),
-        (0.5, 0),
-    ],
-    ids=[
-        "int_input",
-        "float_input",
-    ],
-)
-def test_convert_to_nanoseconds_wrong_inputs(input_value, expected):
-    assert convert_to_nanoseconds(input_value) == expected
-
-
-def test_convert_to_float():
-    assert convert_str_to_float(1) == 1.0
-    assert convert_str_to_float(0.5) == 0.5
-    assert convert_str_to_float("2.5") == 2.5
-    assert convert_str_to_float("invalid") is None
-    assert convert_str_to_float(None) is None
+from airbrakes.utils import arg_parser, deadband
 
 
 def test_deadband():
@@ -112,7 +76,7 @@ class TestArgumentParsing:
         assert len(args.__dict__) == 8
         assert args.__dict__.keys() == {
             "mode",
-            "scale",
+            "preset",
             "real_servo",
             "keep_log_file",
             "fast_replay",
@@ -122,7 +86,7 @@ class TestArgumentParsing:
         }
 
         assert args.mode == "sim"
-        assert args.scale == "sub-scale"
+        assert args.preset == "sub-scale"
         assert args.real_servo is True
         assert args.keep_log_file is True
         assert args.fast_replay is True
@@ -173,7 +137,7 @@ class TestArgumentParsing:
             ["sim", "-r", "-l", "-f", "-c"],
             ["sim", "legacy", "-r"],
         ],
-        ids=["mock_with_path", "sim_with_common_args", "sim_with_scale_and_common_args"],
+        ids=["mock_with_path", "sim_with_common_args", "sim_with_preset_and_common_args"],
     )
     def test_shared_arguments(self, monkeypatch, args):
         """Tests that shared arguments are correctly parsed across 'mock' and 'sim'."""
@@ -183,9 +147,9 @@ class TestArgumentParsing:
         if "mock" in args.mode:
             assert args.path == Path("mock/data/path")
         elif "sim" in args.mode:
-            assert args.scale
+            assert args.preset
             assert not hasattr(args, "path")
-            if args.scale == "legacy":
+            if args.preset == "legacy":
                 assert args.real_servo is True
                 assert args.keep_log_file is False
                 assert args.fast_replay is False
@@ -196,13 +160,13 @@ class TestArgumentParsing:
                 assert args.fast_replay is True
                 assert args.real_camera is True
 
-    def test_sim_default_scale(self, monkeypatch):
-        """Tests that the 'sim' mode defaults to 'full-scale' if no scale is provided."""
+    def test_sim_default_preset(self, monkeypatch):
+        """Tests that the 'sim' mode defaults to 'full-scale' if no preset is provided."""
         monkeypatch.setattr(sys, "argv", ["main.py", "sim"])
 
         args = arg_parser()
         assert args.mode == "sim"
-        assert args.scale == "full-scale"
+        assert args.preset == "full-scale"
 
     def test_help_output(self, monkeypatch, capsys):
         """Tests that help output includes global and subparser-specific arguments."""


### PR DESCRIPTION
A lot of our comments and documentation has slowly been getting outdated, and with Airbrakes code getting closer to being "done", a really thorough polish on our comments and documentation should be done so that incoming programmers in the future can learn from us.

Some of the changes I have made so far, or that are in progress:
- using the word "program" instead of "script", to differentiate between running Airbrakes and running scripts in the `scripts` folder.
- Deleting some unused functions in `utils`
- changing comments that mention `DataProcessor` to `IMUDataProcessor`
- adding `:param:` and `:return:` to methods
- renaming the `scale` simulation argument to `preset`
- Using "Airbrakes" when referring to the AirbrakesV2 program, and "air brakes" when referring to the physical air brakes system