### PR TITLE
Initial Cython implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ out/
 logs/
 
 build/
-AirbrakesV2.egg-info/
+airbrakes.egg-info/
 .venv/
 
 test_logs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,7 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 add_custom_command(
   OUTPUT logger.c
   COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
-  COMMAND "${Python_EXECUTABLE}" -m cython
-          "${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
-          --output-file "${CMAKE_CURRENT_BINARY_DIR}/logger.c"
+  COMMAND sh -c "uv run python -m cython '${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py' -3 --output-file '${CMAKE_CURRENT_BINARY_DIR}/logger.c'"
   DEPENDS airbrakes/telemetry/logger.py
   VERBATIM
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.25)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
+
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+
+add_custom_command(
+  OUTPUT logger.c
+  COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
+  COMMAND "${Python_EXECUTABLE}" -m cython
+          "${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
+          --output-file "${CMAKE_CURRENT_BINARY_DIR}/logger.c"
+  DEPENDS airbrakes/telemetry/logger.py
+  VERBATIM
+)
+
+python_add_library(logger MODULE logger.c WITH_SOABI)
+install(TARGETS logger DESTINATION ${SKBUILD_PROJECT_NAME}/telemetry)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(py_file IN LISTS AIRBRAKES_PY_FILES)
 
   add_custom_command(
     OUTPUT ${c_file_output_dir}
-    COMMAND sh -c "uv run python -m cython '${py_file}' -3 --output-file '${c_file_output_dir}' -X boundscheck=false"
+    COMMAND sh -c "uv run --no-sync --active python -m cython '${py_file}' -3 --output-file '${c_file_output_dir}' -X boundscheck=false"
     DEPENDS ${py_file}
     COMMENT "Cythonizing ${rel_path}"
     VERBATIM
@@ -54,7 +54,7 @@ endforeach()
 # add_custom_command(
 #   OUTPUT logger.c
 #   COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
-#   COMMAND sh -c "uv run python -m cython '${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py' -3 --output-file '${CMAKE_CURRENT_BINARY_DIR}/logger.c'"
+#   COMMAND sh -c "uv run --no-sync --active python -m cython '${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py' -3 --output-file '${CMAKE_CURRENT_BINARY_DIR}/logger.c'"
 #   DEPENDS airbrakes/telemetry/logger.py
 #   VERBATIM
 # )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,62 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 
-add_custom_command(
-  OUTPUT logger.c
-  COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
-  COMMAND sh -c "uv run python -m cython '${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py' -3 --output-file '${CMAKE_CURRENT_BINARY_DIR}/logger.c'"
-  DEPENDS airbrakes/telemetry/logger.py
-  VERBATIM
-)
+file(GLOB_RECURSE AIRBRAKES_PY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/*.py")
 
-python_add_library(logger MODULE logger.c WITH_SOABI)
-install(TARGETS logger DESTINATION ${SKBUILD_PROJECT_NAME}/telemetry)
+message(STATUS "cmake dir: ${CMAKE_CURRENT_SOURCE_DIR}")  # This is the root directory of the project
+message(STATUS "skbuild dir: ${SKBUILD_PROJECT_NAME}")  # name of the project from pyproject.toml (airbrakes)
+message(STATUS "binary dir: ${CMAKE_CURRENT_BINARY_DIR}")  # the build directory set in pyproject.toml (build/)
+set(AIRBRAKES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/airbrakes")  # The airbrakes package directory
+
+foreach(py_file IN LISTS AIRBRAKES_PY_FILES)
+
+  # Skip __init__.py files:
+  if(py_file MATCHES "__init__.py$")
+    continue()
+  endif()
+
+  message(STATUS "In loop for: ${py_file}")
+  # Get relative path from project root (e.g. airbrakes/telemetry/logger.py)
+  file(RELATIVE_PATH rel_path "${CMAKE_CURRENT_SOURCE_DIR}" "${py_file}")
+  get_filename_component(dir_part "${rel_path}" DIRECTORY)  # Gets the directory (package) name (e.g. `airbrakes/telemetry`)
+  get_filename_component(base_name "${rel_path}" NAME_WE)  # Gets the file name without extension (e.g. `logger`)
+
+  # Generate output paths preserving directory structure
+  # This will be the output C file (e.g. build/airbrakes/telemetry/logger.c)
+  set(c_file_output_dir "${CMAKE_CURRENT_BINARY_DIR}/${dir_part}/${base_name}.c")
+  message(STATUS "c_file_output_dir: ${c_file_output_dir}")
+
+  add_custom_command(
+    OUTPUT ${c_file_output_dir}
+    COMMAND sh -c "uv run python -m cython '${py_file}' -3 --output-file '${c_file_output_dir}' -X boundscheck=false"
+    DEPENDS ${py_file}
+    COMMENT "Cythonizing ${rel_path}"
+    VERBATIM
+  )
+
+  # In order to properly install the .so file, the target name needs to match the file name,
+  # and the DESTINATION must be in the airbrakes/ directory. Note: Using ${CMAKE_SOURCE_DIR} will install the .so file in the root directory,
+  # that works, but then the module isn't rebuilt automatically when the source file changes
+  # That's why we just use the ${dir_part} variable to install the .so file in the correct directory,
+  # which installs it in the .venv/lib/python3.x/site-packages/airbrakes/ directory.
+
+  message(STATUS "Installing ${base_name} to ${dir_part}")
+  python_add_library("${base_name}" MODULE ${c_file_output_dir} WITH_SOABI)
+  
+  # Install with original package structure
+  install(TARGETS "${base_name}" DESTINATION "${dir_part}")
+endforeach()
+
+# old working code for one file:
+
+# add_custom_command(
+#   OUTPUT logger.c
+#   COMMENT "Compiling ${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py"
+#   COMMAND sh -c "uv run python -m cython '${CMAKE_CURRENT_SOURCE_DIR}/airbrakes/telemetry/logger.py' -3 --output-file '${CMAKE_CURRENT_BINARY_DIR}/logger.c'"
+#   DEPENDS airbrakes/telemetry/logger.py
+#   VERBATIM
+# )
+
+# python_add_library(logger MODULE logger.c WITH_SOABI)
+# install(TARGETS logger DESTINATION ${SKBUILD_PROJECT_NAME}/telemetry)
+

--- a/airbrakes/hardware/base_imu.py
+++ b/airbrakes/hardware/base_imu.py
@@ -4,6 +4,8 @@ the IMU (Inertial measurement unit) on the rocket."""
 import contextlib
 import sys
 
+import cython
+
 from airbrakes.constants import IMU_TIMEOUT_SECONDS, MAX_FETCHED_PACKETS, STOP_SIGNAL
 from airbrakes.telemetry.packets.imu_data_packet import (
     IMUDataPacket,
@@ -17,6 +19,10 @@ else:
     from queue import Empty
 
 from multiprocessing import Process, TimeoutError, Value
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
 
 
 class BaseIMU:
@@ -35,14 +41,14 @@ class BaseIMU:
         """
         Initialises object using arguments passed by the constructors of the subclasses.
         """
-        self._data_fetch_process = data_fetch_process
-        self._data_queue = data_queue
+        self._data_fetch_process: Process = data_fetch_process
+        self._data_queue: Queue = data_queue
         # Makes a boolean value that is shared between processes
-        self._running = Value("b", False)
+        self._running: Synchronized = Value("b", False)
         self._fetched_imu_packets = Value("i", 0)
 
     @property
-    def fetched_imu_packets(self) -> int:
+    def fetched_imu_packets(self) -> cython.uint:
         """
         :return: The number of data packets fetched from the IMU per iteration. Useful for measuring
         the performance of our loop.
@@ -50,7 +56,7 @@ class BaseIMU:
         return self._fetched_imu_packets.value
 
     @property
-    def queue_size(self) -> int:
+    def queue_size(self) -> cython.uint:
         """
         :return: The number of data packets in the queue.
         """

--- a/airbrakes/hardware/imu.py
+++ b/airbrakes/hardware/imu.py
@@ -165,6 +165,8 @@ class IMU(BaseIMU):
                                 raw_data_packet.invalid_fields = []
                             raw_data_packet.invalid_fields.append(data_point.channelName())
 
+                    messages.append(raw_data_packet)
+
                 elif descriptor_set == ESTIMATED_DESCRIPTOR_SET:
                     imu_data_packet: EstimatedDataPacket = EstimatedDataPacket(timestamp)
                     # Iterate through each data point in the packet.

--- a/airbrakes/main.py
+++ b/airbrakes/main.py
@@ -5,6 +5,7 @@ import argparse
 import sys
 import time
 
+import cython
 from gpiozero.pins.mock import MockFactory, MockPWMPin
 
 from airbrakes.airbrakes import AirbrakesContext
@@ -52,6 +53,9 @@ def run_sim_flight() -> None:
 
 
 def run_flight(args: argparse.Namespace) -> None:
+    if cython.compiled:
+        print("Running in compiled mode")
+
     mock_time_start = time.time()
 
     servo, imu, camera, logger, data_processor, apogee_predictor = create_components(args)

--- a/airbrakes/mock/display.py
+++ b/airbrakes/mock/display.py
@@ -131,7 +131,7 @@ class FlightDisplay:
         most useful on real flights, where it is hard to see the display due to sunlight, or
         """
         # We only care about standby state and if we are running a real:
-        if self._airbrakes.state.name != "StandbyState" or self._args.mock:
+        if self._airbrakes.state.name != "StandbyState" or self._args.mode != "real":
             return
 
         has_invalid_fields = False
@@ -150,11 +150,11 @@ class FlightDisplay:
         if self._airbrakes.imu.fetched_imu_packets > 50:
             imu_queue_backlog = True
 
-        if (
-            self._pitch_at_startup
-            and abs(self._airbrakes.data_processor.average_pitch - self._pitch_at_startup) > 1
-        ):
-            pitch_drift = True
+        # if (
+        #     self._pitch_at_startup
+        #     and abs(self._airbrakes.data_processor.average_pitch - self._pitch_at_startup) > 1
+        # ):
+        #     pitch_drift = True
 
         if has_invalid_fields or has_negative_velocity or imu_queue_backlog or pitch_drift:
             print("\a", end="")
@@ -197,7 +197,7 @@ class FlightDisplay:
 
         fetched_packets_in_main = len(self._airbrakes.imu_data_packets)
         fetched_packets_from_imu = (
-            self._airbrakes.imu.fetched_imu_packets if not self._args.mock else "N/A"
+            self._airbrakes.imu.fetched_imu_packets if self._args.mode != "mock" else "N/A"
         )
 
         data_processor = self._airbrakes.data_processor
@@ -235,8 +235,8 @@ class FlightDisplay:
             )
 
         # Assign the startup pitch value when it is available:
-        if not self._pitch_at_startup and data_processor._current_orientation_quaternions:
-            self._pitch_at_startup = data_processor.average_pitch
+        # if not self._pitch_at_startup and data_processor._current_orientation_quaternions:
+        #     self._pitch_at_startup = data_processor.average_pitch
 
         # Prepare output
         output = [
@@ -260,7 +260,7 @@ class FlightDisplay:
             output.extend(
                 [
                     f"{Y}{'=' * 18} DEBUG INFO {'=' * 17}{RESET}",
-                    f"Average pitch:                   {G}{data_processor.average_pitch:<10.2f}{RESET} {R}deg{RESET}",  # noqa: E501
+                    # f"Average pitch:                   {G}{data_processor.average_pitch:<10.2f}{RESET} {R}deg{RESET}",  # noqa: E501
                     f"Average acceleration:            {G}{data_processor.average_vertical_acceleration:<10.2f}{RESET} {R}m/s^2{RESET}",  # noqa: E501
                     f"Convergence Time:                {G}{self._convergence_time:<10.2f}{RESET} {R}s{RESET}",  # noqa: E501
                     f"Convergence Height:              {G}{self._convergence_height:<10.2f}{RESET} {R}m{RESET}",  # noqa: E501

--- a/airbrakes/mock/display.py
+++ b/airbrakes/mock/display.py
@@ -292,13 +292,12 @@ class FlightDisplay:
             print(self.MOVE_CURSOR_UP * len(output), end="", flush=True)
 
         # Print the end of replay message if the replay has ended
-        match end_type:
-            case DisplayEndingType.NATURAL:
-                print(f"{R}{'=' * 14} END OF REPLAY {'=' * 14}{RESET}")
-            case DisplayEndingType.INTERRUPTED:
-                print(f"{R}{'=' * 12} INTERRUPTED REPLAY {'=' * 13}{RESET}")
-            case DisplayEndingType.TAKEOFF:
-                print(f"{R}{'=' * 13} ROCKET LAUNCHED {'=' * 14}{RESET}")
+        if end_type == DisplayEndingType.NATURAL:
+            print(f"{R}{'=' * 14} END OF REPLAY {'=' * 14}{RESET}")
+        elif end_type == DisplayEndingType.INTERRUPTED:
+            print(f"{R}{'=' * 12} INTERRUPTED REPLAY {'=' * 13}{RESET}")
+        elif end_type == DisplayEndingType.TAKEOFF:
+            print(f"{R}{'=' * 13} ROCKET LAUNCHED {'=' * 14}{RESET}")
 
     def prepare_process_dict(self) -> dict[str, psutil.Process]:
         """

--- a/airbrakes/simulation/sim_config.py
+++ b/airbrakes/simulation/sim_config.py
@@ -114,12 +114,11 @@ def get_configuration(config_type: str) -> SimulationConfig:
     "sub-scale" or "legacy".
     :return: The configuration for the simulation
     """
-    match config_type:
-        case "full-scale":
-            return FULL_SCALE_CONFIG
-        case "sub-scale":
-            return SUB_SCALE_CONFIG
-        case "legacy":
-            return LEGACY_CONFIG
-        case _:
-            raise ValueError(f"Invalid config type: {config_type}")
+    if config_type == "full-scale":
+        return FULL_SCALE_CONFIG
+    if config_type == "sub-scale":
+        return SUB_SCALE_CONFIG
+    if config_type == "legacy":
+        return LEGACY_CONFIG
+
+    raise ValueError(f"Invalid config type: {config_type}")

--- a/airbrakes/simulation/sim_utils.py
+++ b/airbrakes/simulation/sim_utils.py
@@ -68,14 +68,13 @@ def get_random_value(
             rms = coeffs[0] * reference_value + coeffs[1]
             return random.gauss(0, value_configs.std_dev) * rms * np.sqrt(2)
 
-    match value_configs.type:
-        case "constant":
-            return value_configs.value
-        case "uniform":
-            return random.uniform(rand_range[0], rand_range[1])
-        case "normal":
-            if value_configs.mean is not None:
-                return random.gauss(value_configs.mean, value_configs.std_dev)
-            if value_configs.std_dev is not None:
-                return random.gauss(0, value_configs.std_dev)
-            raise Exception(f"invalid random config format for {value_configs}")
+    if value_configs.type == "constant":
+        return value_configs.value
+    if value_configs.type == "uniform":
+        return random.uniform(rand_range[0], rand_range[1])
+    if value_configs.type == "normal":
+        if value_configs.mean is not None:
+            return random.gauss(value_configs.mean, value_configs.std_dev)
+        if value_configs.std_dev is not None:
+            return random.gauss(0, value_configs.std_dev)
+    raise Exception(f"invalid random config format for {value_configs}")

--- a/airbrakes/telemetry/logger.py
+++ b/airbrakes/telemetry/logger.py
@@ -1,3 +1,4 @@
+# cython: language_level=3
 """Module for logging data to a CSV file in real time."""
 
 import csv
@@ -6,7 +7,7 @@ import signal
 import sys
 from collections import deque
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from airbrakes.telemetry.packets.apogee_predictor_data_packet import ApogeePredictorDataPacket
 from airbrakes.telemetry.packets.servo_data_packet import ServoDataPacket
@@ -31,6 +32,9 @@ from airbrakes.telemetry.packets.context_data_packet import ContextDataPacket
 from airbrakes.telemetry.packets.imu_data_packet import EstimatedDataPacket, IMUDataPacket
 from airbrakes.telemetry.packets.logger_data_packet import LoggerDataPacket
 from airbrakes.telemetry.packets.processor_data_packet import ProcessorDataPacket
+
+if TYPE_CHECKING:
+    import cython
 
 
 class Logger:
@@ -151,7 +155,7 @@ class Logger:
         """
         logger_data_packets: list[LoggerDataPacket] = []
 
-        index = 0  # Index to loop over processor data packets:
+        index: cython.uint = 0  # Index to loop over processor data packets:
 
         # Convert the imu data packets to a dictionary:
         for imu_data_packet in imu_data_packets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,13 @@ sim = "airbrakes.main:run_sim_flight"
 [tool.scikit-build]
 build-dir = "build/{wheel_tag}"
 editable.rebuild = true
+editable.verbose = false
 wheel.packages = ["airbrakes"]
 wheel.install-dir = "."
+build.verbose = true
 
 [tool.scikit-build.cmake]
 args = ["-DSKBUILD=ON"]
-verbose = true
 
 [build-system]
 requires = ["scikit-build-core", "cython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
     "ruff",
     "pre-commit",
     "pytest-benchmark>=5.1.0",
-    "scikit-build-core>=0.10.7",  # Needed for installs with --no-build-isolation, for cython builds
 ]
 # Need to run `sudo apt install `libcap-dev`, `libcamera-dev`,
 # `libkms++-dev`, `libfmt-dev`, `libdrm-dev` to build and install everything camera related.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "AirbrakesV2"
+name = "airbrakes"
 description = "Logic for airbrakes as a part of the NASA Student Launch Competition"
 requires-python = ">=3.13"
 version = "1.1.0"
@@ -16,6 +16,7 @@ dependencies = [
     "faster-fifo; sys_platform != 'win32'",
     "textual",
     "python-mscl>=67.0.0",
+    "cython>=3.0.11",
 ]
 
 [dependency-groups]
@@ -25,6 +26,7 @@ dev = [
     "ruff",
     "pre-commit",
     "pytest-benchmark>=5.1.0",
+    "scikit-build-core>=0.10.7",  # Needed for installs with --no-build-isolation, for cython builds
 ]
 # Need to run `sudo apt install `libcap-dev`, `libcamera-dev`,
 # `libkms++-dev`, `libfmt-dev`, `libdrm-dev` to build and install everything camera related.
@@ -39,21 +41,31 @@ mock = "airbrakes.main:run_mock_flight"
 real = "airbrakes.main:run_real_flight"
 sim = "airbrakes.main:run_sim_flight"
 
+[tool.scikit-build]
+build-dir = "build/{wheel_tag}"
+editable.rebuild = true
+wheel.packages = ["airbrakes"]
+wheel.install-dir = "."
+
+[tool.scikit-build.cmake]
+args = ["-DSKBUILD=ON"]
+verbose = true
+
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["scikit-build-core", "cython"]
+build-backend = "scikit_build_core.build"
 
 # UV:
 [tool.uv]
 python-preference = "only-managed"
 
-# HATCH:
-[tool.hatch.build.targets.wheel]
-packages = ["airbrakes"]
+# # HATCH:
+# [tool.hatch.build.targets.wheel]
+# packages = ["airbrakes"]
 
-[tool.hatch.build.targets.wheel.force-include]
-# specify one launch file so that the mock flight can be run as a demo with uvx.
-"launch_data/genesis_launch_1.csv" = "/launch_data/genesis_launch_1.csv"
+# [tool.hatch.build.targets.wheel.force-include]
+# # specify one launch file so that the mock flight can be run as a demo with uvx.
+# "launch_data/genesis_launch_1.csv" = "/launch_data/genesis_launch_1.csv"
 
 # RUFF:
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -149,19 +149,19 @@ wheels = [
 
 [[package]]
 name = "cython"
-version = "3.0.11"
+version = "3.0.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/4d/b720d6000f4ca77f030bd70f12550820f0766b568e43f11af7f7ad9061aa/cython-3.0.11.tar.gz", hash = "sha256:7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff", size = 2755544 }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/25/886e197c97a4b8e254173002cdc141441e878ff29aaa7d9ba560cd6e4866/cython-3.0.12.tar.gz", hash = "sha256:b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc", size = 2757617 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/19/1d7164b724f62b67c59aa3531a2be8ed1a0c7e4e80afcc6502d8409c4ee3/Cython-3.0.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4341d6a64d47112884e0bcf31e6c075268220ee4cd02223047182d4dda94d637", size = 3134881 },
-    { url = "https://files.pythonhosted.org/packages/0a/d7/8d834d7ec4b6e55db857f44e328246d40cb527917040fabf3c48d27609b3/Cython-3.0.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351955559b37e6c98b48aecb178894c311be9d731b297782f2b78d111f0c9015", size = 3330582 },
-    { url = "https://files.pythonhosted.org/packages/1c/ae/d520f3cd94a8926bc47275a968e51bbc669a28f27a058cdfc5c3081fbbf7/Cython-3.0.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c02361af9bfa10ff1ccf967fc75159e56b1c8093caf565739ed77a559c1f29f", size = 3503750 },
-    { url = "https://files.pythonhosted.org/packages/6e/e4/45c556f4a6d40b6938368d420d3c985bbef9088b7d4a8d8c6648d50e4a94/Cython-3.0.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6823aef13669a32caf18bbb036de56065c485d9f558551a9b55061acf9c4c27f", size = 3566498 },
-    { url = "https://files.pythonhosted.org/packages/ce/2d/544f6aa3cab31b99ddb07e7eaaaca6a43db52fe0dc59090195c48fc0b033/Cython-3.0.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6fb68cef33684f8cc97987bee6ae919eee7e18ee6a3ad7ed9516b8386ef95ae6", size = 3389063 },
-    { url = "https://files.pythonhosted.org/packages/55/1a/9d871cc1514df273cd2ccfe3efe5ff1df509ce11768c02a834052709f152/Cython-3.0.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:790263b74432cb997740d73665f4d8d00b9cd1cecbdd981d93591ddf993d4f12", size = 3596353 },
-    { url = "https://files.pythonhosted.org/packages/47/4e/4db412f595de4b2224a81ea5332ce107ce3e93bf87275c78648f2e3e37b8/Cython-3.0.11-cp313-cp313-win32.whl", hash = "sha256:e6dd395d1a704e34a9fac00b25f0036dce6654c6b898be6f872ac2bb4f2eda48", size = 2602768 },
-    { url = "https://files.pythonhosted.org/packages/e7/91/8a29e1bce2f8a893a4c24874943b64e8ede14fac9990bd4a3f13a46c2720/Cython-3.0.11-cp313-cp313-win_amd64.whl", hash = "sha256:52186101d51497519e99b60d955fd5cb3bf747c67f00d742e70ab913f1e42d31", size = 2784414 },
-    { url = "https://files.pythonhosted.org/packages/43/39/bdbec9142bc46605b54d674bf158a78b191c2b75be527c6dcf3e6dfe90b8/Cython-3.0.11-py2.py3-none-any.whl", hash = "sha256:0e25f6425ad4a700d7f77cd468da9161e63658837d1bc34861a9861a4ef6346d", size = 1171267 },
+    { url = "https://files.pythonhosted.org/packages/67/ad/550ddcb8b5a5d9949fe6606595cce36984c1d42309f1e04af98f5933a7ea/Cython-3.0.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4ee6f1ea1bead8e6cbc4e64571505b5d8dbdb3b58e679d31f3a84160cebf1a1a", size = 3393574 },
+    { url = "https://files.pythonhosted.org/packages/34/de/ade0a80bea17197662e23d39d3d3fbf89e9e99e6ad91fd95ab87120edb3a/Cython-3.0.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57aefa6d3341109e46ec1a13e3a763aaa2cbeb14e82af2485b318194be1d9170", size = 3367198 },
+    { url = "https://files.pythonhosted.org/packages/a8/30/7f48207ea13dab46604db0dd388e807d53513ba6ad1c34462892072f8f8c/Cython-3.0.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:879ae9023958d63c0675015369384642d0afb9c9d1f3473df9186c42f7a9d265", size = 3535849 },
+    { url = "https://files.pythonhosted.org/packages/81/ab/f61c79fa14bd433a7dfd1548c5e00d9bd18b557c2f836aaece4fb1b22f34/Cython-3.0.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:36fcd584dae547de6f095500a380f4a0cce72b7a7e409e9ff03cb9beed6ac7a1", size = 3559079 },
+    { url = "https://files.pythonhosted.org/packages/d0/d1/1dbf17061229ccd35d5c0eed659fab60c2e50d2eadfa2a5729e753b6f4d0/Cython-3.0.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:62b79dcc0de49efe9e84b9d0e2ae0a6fc9b14691a65565da727aa2e2e63c6a28", size = 3436649 },
+    { url = "https://files.pythonhosted.org/packages/2d/d4/9ce42fff6de5550f870cdde9a1482d69ea66a1249a88fa0d0df9adebfb1a/Cython-3.0.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4aa255781b093a8401109d8f2104bbb2e52de7639d5896aefafddc85c30e0894", size = 3644025 },
+    { url = "https://files.pythonhosted.org/packages/e3/89/b0c847f9df92af3ef11281b6811c000bd6f8ce0db02e4374397f8d67f829/Cython-3.0.12-cp313-cp313-win32.whl", hash = "sha256:77d48f2d4bab9fe1236eb753d18f03e8b2619af5b6f05d51df0532a92dfb38ab", size = 2604911 },
+    { url = "https://files.pythonhosted.org/packages/a6/5f/bbfaf2b5f7bf78854ecbc82f8473a3892ae5580e0c5bd0d4a82580b39ed3/Cython-3.0.12-cp313-cp313-win_amd64.whl", hash = "sha256:86c304b20bd57c727c7357e90d5ba1a2b6f1c45492de2373814d7745ef2e63b4", size = 2786786 },
+    { url = "https://files.pythonhosted.org/packages/27/6b/7c87867d255cbce8167ed99fc65635e9395d2af0f0c915428f5b17ec412d/Cython-3.0.12-py2.py3-none-any.whl", hash = "sha256:0038c9bae46c459669390e53a1ec115f8096b2e4647ae007ff1bf4e6dee92806", size = 1171640 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,11 +2,12 @@ version = 1
 requires-python = ">=3.13"
 
 [[package]]
-name = "airbrakesv2"
+name = "airbrakes"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorama" },
+    { name = "cython" },
     { name = "faster-fifo", marker = "sys_platform != 'win32'" },
     { name = "gpiozero" },
     { name = "msgspec" },
@@ -31,11 +32,13 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-build-core" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "colorama" },
+    { name = "cython", specifier = ">=3.0.11" },
     { name = "faster-fifo", marker = "sys_platform != 'win32'" },
     { name = "gpiozero" },
     { name = "msgspec" },
@@ -60,6 +63,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-build-core", specifier = ">=0.10.7" },
 ]
 
 [[package]]
@@ -141,6 +145,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/69/b3f2416725621e9f112e74e8470793d5b5995f146f596f133678a633b77e/coverage-7.6.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f93531882a5f68c28090f901b1d135de61b56331bba82028489bc51bdd818d2", size = 248737 },
     { url = "https://files.pythonhosted.org/packages/3c/6e/fe899fb937657db6df31cc3e61c6968cb56d36d7326361847440a430152e/coverage-7.6.10-cp313-cp313t-win32.whl", hash = "sha256:89d76815a26197c858f53c7f6a656686ec392b25991f9e409bcef020cd532312", size = 211611 },
     { url = "https://files.pythonhosted.org/packages/1c/55/52f5e66142a9d7bc93a15192eba7a78513d2abf6b3558d77b4ca32f5f424/coverage-7.6.10-cp313-cp313t-win_amd64.whl", hash = "sha256:54a5f0f43950a36312155dae55c505a76cd7f2b12d26abeebbe7a0b36dbc868d", size = 212781 },
+]
+
+[[package]]
+name = "cython"
+version = "3.0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/4d/b720d6000f4ca77f030bd70f12550820f0766b568e43f11af7f7ad9061aa/cython-3.0.11.tar.gz", hash = "sha256:7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff", size = 2755544 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/19/1d7164b724f62b67c59aa3531a2be8ed1a0c7e4e80afcc6502d8409c4ee3/Cython-3.0.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4341d6a64d47112884e0bcf31e6c075268220ee4cd02223047182d4dda94d637", size = 3134881 },
+    { url = "https://files.pythonhosted.org/packages/0a/d7/8d834d7ec4b6e55db857f44e328246d40cb527917040fabf3c48d27609b3/Cython-3.0.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351955559b37e6c98b48aecb178894c311be9d731b297782f2b78d111f0c9015", size = 3330582 },
+    { url = "https://files.pythonhosted.org/packages/1c/ae/d520f3cd94a8926bc47275a968e51bbc669a28f27a058cdfc5c3081fbbf7/Cython-3.0.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c02361af9bfa10ff1ccf967fc75159e56b1c8093caf565739ed77a559c1f29f", size = 3503750 },
+    { url = "https://files.pythonhosted.org/packages/6e/e4/45c556f4a6d40b6938368d420d3c985bbef9088b7d4a8d8c6648d50e4a94/Cython-3.0.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6823aef13669a32caf18bbb036de56065c485d9f558551a9b55061acf9c4c27f", size = 3566498 },
+    { url = "https://files.pythonhosted.org/packages/ce/2d/544f6aa3cab31b99ddb07e7eaaaca6a43db52fe0dc59090195c48fc0b033/Cython-3.0.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6fb68cef33684f8cc97987bee6ae919eee7e18ee6a3ad7ed9516b8386ef95ae6", size = 3389063 },
+    { url = "https://files.pythonhosted.org/packages/55/1a/9d871cc1514df273cd2ccfe3efe5ff1df509ce11768c02a834052709f152/Cython-3.0.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:790263b74432cb997740d73665f4d8d00b9cd1cecbdd981d93591ddf993d4f12", size = 3596353 },
+    { url = "https://files.pythonhosted.org/packages/47/4e/4db412f595de4b2224a81ea5332ce107ce3e93bf87275c78648f2e3e37b8/Cython-3.0.11-cp313-cp313-win32.whl", hash = "sha256:e6dd395d1a704e34a9fac00b25f0036dce6654c6b898be6f872ac2bb4f2eda48", size = 2602768 },
+    { url = "https://files.pythonhosted.org/packages/e7/91/8a29e1bce2f8a893a4c24874943b64e8ede14fac9990bd4a3f13a46c2720/Cython-3.0.11-cp313-cp313-win_amd64.whl", hash = "sha256:52186101d51497519e99b60d955fd5cb3bf747c67f00d742e70ab913f1e42d31", size = 2784414 },
+    { url = "https://files.pythonhosted.org/packages/43/39/bdbec9142bc46605b54d674bf158a78b191c2b75be527c6dcf3e6dfe90b8/Cython-3.0.11-py2.py3-none-any.whl", hash = "sha256:0e25f6425ad4a700d7f77cd468da9161e63658837d1bc34861a9861a4ef6346d", size = 1171267 },
 ]
 
 [[package]]
@@ -380,6 +401,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
     { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
     { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]
@@ -711,6 +741,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302 },
     { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051 },
     { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251 },
+]
+
+[[package]]
+name = "scikit-build-core"
+version = "0.10.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/75/ad5664c8050bbbea46a5f2b6a3dfbc6e6cf284826c0eee0a12f861364b3f/scikit_build_core-0.10.7.tar.gz", hash = "sha256:04cbb59fe795202a7eeede1849112ee9dcbf3469feebd9b8b36aa541336ac4f8", size = 255019 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fe/90476c4f6a1b2f922efa00d26e876dd40c7279e28ec18f08f0851ad21ba6/scikit_build_core-0.10.7-py3-none-any.whl", hash = "sha256:5e13ab7ca7c3c6dd019607c3a6f53cba67dade8757c4c4f75b459e2f90e4dbc3", size = 165511 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,6 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "scikit-build-core" },
 ]
 
 [package.metadata]
@@ -63,7 +62,6 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "scikit-build-core", specifier = ">=0.10.7" },
 ]
 
 [[package]]
@@ -404,15 +402,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
-]
-
-[[package]]
 name = "picamera2"
 version = "0.3.24"
 source = { registry = "https://pypi.org/simple" }
@@ -741,19 +730,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302 },
     { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051 },
     { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251 },
-]
-
-[[package]]
-name = "scikit-build-core"
-version = "0.10.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "pathspec" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/75/ad5664c8050bbbea46a5f2b6a3dfbc6e6cf284826c0eee0a12f861364b3f/scikit_build_core-0.10.7.tar.gz", hash = "sha256:04cbb59fe795202a7eeede1849112ee9dcbf3469feebd9b8b36aa541336ac4f8", size = 255019 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/fe/90476c4f6a1b2f922efa00d26e876dd40c7279e28ec18f08f0851ad21ba6/scikit_build_core-0.10.7-py3-none-any.whl", hash = "sha256:5e13ab7ca7c3c6dd019607c3a6f53cba67dade8757c4c4f75b459e2f90e4dbc3", size = 165511 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds Cython to the build process to compile the .py files and try to speed the IMU even more.

Currently, every .py file is compiled, and I didn't see any noticeable performance improvements right off. In fact it seems to be slightly slower if anything (checked by looking at how long it takes to run a mock with `-f`). Which is kinda sad since Cython's documentation said you'd get a 30-60% speedup by simply compiling and not changing anything.

Some notes on the changes so far: 
- Cython does not support match statements yet, so I had to convert them to `if-else`. https://github.com/cython/cython/issues/4029
- Cython caught some type bugs, but most of our code is typed correctly. 
- I am compiling with `boundscheck=False`, which means that all accesses of a list/string/tuple via `[]` must not raise `IndexError`, otherwise the code will segfault/crash.

Performance changes we could do:

- Half of our loops are still going to be done in python since they are using python objects. E.g. `imu_data_packets` contains both Raw and Est packets, so we would literally have to check the type every time in the loop. So unless we change the architecture significantly, there might not be much we can do.
- We can tell cython to inline some of our functions, would be useful in the IMU loop for example.
- The numpy part can be optimized a little more, we can directly access the memoryview and do a little bit of pre-allocation.