### PR TITLE
Integrating vertical velocity for altitude during air brakes extension

### DIFF
--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -196,6 +196,8 @@ class AirbrakesContext:
         # Because the IMUDataProcessor only uses Estimated Data Packets to create Processor Data
         # Packets, we only update the apogee predictor when Estimated Data Packets are ready.
         if self.est_data_packets:
+            # if not self.last_apogee_predictor_packet.predicted_apogee:
+            #     self.data_processor.filter_vertical_velocities()
             self.apogee_predictor.update(self.processor_data_packets)
 
     def generate_data_packets(self) -> None:

--- a/airbrakes/airbrakes.py
+++ b/airbrakes/airbrakes.py
@@ -179,12 +179,14 @@ class AirbrakesContext:
         Extends the air brakes to the maximum extension.
         """
         self.servo.set_extended()
+        self.data_processor.use_integrated_altitude = True
 
     def retract_airbrakes(self) -> None:
         """
         Retracts the air brakes to the minimum extension.
         """
         self.servo.set_retracted()
+        self.data_processor.use_integrated_altitude = False
 
     def predict_apogee(self) -> None:
         """

--- a/airbrakes/telemetry/logger.py
+++ b/airbrakes/telemetry/logger.py
@@ -197,6 +197,7 @@ class Logger:
 
                 # Now also extract the fields from the ProcessorDataPacket
                 logger_packet.current_altitude = processor_data_packets[index].current_altitude
+                logger_packet.pressure_altitude = processor_data_packets[index].pressure_altitude
                 logger_packet.vertical_velocity = processor_data_packets[index].vertical_velocity
                 logger_packet.vertical_acceleration = processor_data_packets[
                     index

--- a/airbrakes/telemetry/logger.py
+++ b/airbrakes/telemetry/logger.py
@@ -199,6 +199,10 @@ class Logger:
                 logger_packet.current_altitude = processor_data_packets[index].current_altitude
                 logger_packet.pressure_altitude = processor_data_packets[index].pressure_altitude
                 logger_packet.vertical_velocity = processor_data_packets[index].vertical_velocity
+                logger_packet.velocity_from_altitude = processor_data_packets[
+                    index
+                ].velocity_from_altitude
+                logger_packet.filtered_velocity = processor_data_packets[index].filtered_velocity
                 logger_packet.vertical_acceleration = processor_data_packets[
                     index
                 ].vertical_acceleration

--- a/airbrakes/telemetry/packets/logger_data_packet.py
+++ b/airbrakes/telemetry/packets/logger_data_packet.py
@@ -61,6 +61,7 @@ class LoggerDataPacket(msgspec.Struct, array_like=True, kw_only=True):
 
     # Processor Data Packet Fields
     current_altitude: float | None = None
+    integrated_altitude: float | None = None
     vertical_velocity: float | None = None
     vertical_acceleration: float | None = None
 

--- a/airbrakes/telemetry/packets/logger_data_packet.py
+++ b/airbrakes/telemetry/packets/logger_data_packet.py
@@ -63,6 +63,8 @@ class LoggerDataPacket(msgspec.Struct, array_like=True, kw_only=True):
     current_altitude: float | None = None
     pressure_altitude: float | None = None
     vertical_velocity: float | None = None
+    velocity_from_altitude: float | None = None
+    filtered_velocity: float | None = None
     vertical_acceleration: float | None = None
 
     # Apogee Predictor Data Packet Fields

--- a/airbrakes/telemetry/packets/logger_data_packet.py
+++ b/airbrakes/telemetry/packets/logger_data_packet.py
@@ -61,7 +61,7 @@ class LoggerDataPacket(msgspec.Struct, array_like=True, kw_only=True):
 
     # Processor Data Packet Fields
     current_altitude: float | None = None
-    integrated_altitude: float | None = None
+    pressure_altitude: float | None = None
     vertical_velocity: float | None = None
     vertical_acceleration: float | None = None
 

--- a/airbrakes/telemetry/packets/processor_data_packet.py
+++ b/airbrakes/telemetry/packets/processor_data_packet.py
@@ -16,6 +16,10 @@ class ProcessorDataPacket(msgspec.Struct):
     pressure_altitude: np.float64  # This is the zeroed-out pressure altitude of the rocket.
     # This is the velocity of the rocket, in the upward axis (whichever way is up)
     vertical_velocity: np.float64
+    # Velocity of the rocket calculated from differentiating the pressure altitude
+    velocity_from_altitude: np.float64
+    # Velocity of the rocket by filtering together integrated velocity and differentiated velocity
+    filtered_velocity: np.float64
     # This is the acceleration of the rocket in the upwards direction.
     vertical_acceleration: np.float64
     # The time difference between the current and previous data packet.

--- a/airbrakes/telemetry/packets/processor_data_packet.py
+++ b/airbrakes/telemetry/packets/processor_data_packet.py
@@ -10,11 +10,11 @@ class ProcessorDataPacket(msgspec.Struct):
     processed values of the IMU's estimated data.
     """
 
-    current_altitude: np.float64  # This is the zeroed-out altitude of the rocket.
+    # When airbrakes are retracted, the current altitude is the pressure altitude. When deployed,
+    # the current altitude is calculated by integrating the vertical velocity.
+    current_altitude: np.float64
+    pressure_altitude: np.float64  # This is the zeroed-out pressure altitude of the rocket.
     # This is the velocity of the rocket, in the upward axis (whichever way is up)
-    integrated_altitude: np.float64 | None
-    # This is the calculated altitude from integrating the vertical velocity. This will only be
-    # recorded when the air brakes are extended.
     vertical_velocity: np.float64
     # This is the acceleration of the rocket in the upwards direction.
     vertical_acceleration: np.float64

--- a/airbrakes/telemetry/packets/processor_data_packet.py
+++ b/airbrakes/telemetry/packets/processor_data_packet.py
@@ -12,6 +12,9 @@ class ProcessorDataPacket(msgspec.Struct):
 
     current_altitude: np.float64  # This is the zeroed-out altitude of the rocket.
     # This is the velocity of the rocket, in the upward axis (whichever way is up)
+    integrated_altitude: np.float64 | None
+    # This is the calculated altitude from integrating the vertical velocity. This will only be
+    # recorded when the air brakes are extended.
     vertical_velocity: np.float64
     # This is the acceleration of the rocket in the upwards direction.
     vertical_acceleration: np.float64


### PR DESCRIPTION
Due to the pressure change that air brakes extension causes, I think integrating the vertical velocity during the extension period is a good way to keep altitude readings mostly accurate. There is error that comes with integrating three times (integrating gyro for rotating acceleration, integrating for velocity, integrating for altitude), so I might look into filtering algorithms if simply integrating is not accurate enough. 

We are also going to do some physical testing to see if the pressure issue can be prevented entirely with changes to the AVAB, so this branch is not to be merged until that testing is complete