### PR TITLE
Use `os.fsync()` to guarantee disk write

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -113,8 +113,9 @@ LOGS_PATH = Path("logs")
 """The path of the folder to hold the log files in."""
 TEST_LOGS_PATH = Path("test_logs")
 """The path of the folder to hold the test log files in."""
-NUMBER_OF_LINES_TO_LOG_BEFORE_FLUSHING = 100
-"""The number of lines we log before manually flushing the buffer."""
+NUMBER_OF_LINES_TO_LOG_BEFORE_FLUSHING = 1000  # 1 second of data
+"""The number of lines we log before manually flushing the buffer and forcing the OS to write
+to the file."""
 
 STOP_SIGNAL = "STOP"
 """


### PR DESCRIPTION
Closes #171 

Unfortunately there is no easy way to test that this works without changing kernel parameters at runtime like `vm.dirty_writeback_centisecs` to a very high value temporarily. 

Even then, reading a file to check if stuff was written will not work since the file will be read directly from the dirty pages. One way around that would be to specify the [`O_DIRECT`](https://manpages.debian.org/bookworm/manpages-dev/open.2.en.html#O_DIRECT) flag when reading a file. However this needs to be aligned with the block size of the filesystem (usually 4096 bytes, you can check this by running `fdisk -l`), and also the data returned will be in bytes.

There is also no way to specifically check the dirty page size for a file directly.

So while it should be possible to write a test for this, I'm not doing it since I don't want to mess with my kernel parameters every time I run the test suite.