### PR TITLE
Revert "Added altitude and vel fix for when airbrakes deploy"

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -265,7 +265,7 @@ less noisy.
 """
 
 # ----------------- Coasting to Freefall -----------------
-TARGET_APOGEE_METERS = 430
+TARGET_APOGEE_METERS = 1218.16
 """
 The target apogee in meters that we want the rocket to reach. This is used with our bang-bang
 controller to determine when to extend and retract the air brakes.
@@ -296,16 +296,6 @@ LANDED_ACCELERATION_METERS_PER_SECOND_SQUARED = 50.0
 """
 The acceleration in m/s^2 that the rocket must be above before we consider it to have landed. Upon
 landing, the rocket has a large spike in acceleration that is used to detect landing.
-"""
-
-# -------------------------------------------------------
-# Data Processor Configuration
-# -------------------------------------------------------
-
-SECONDS_UNTIL_PRESSURE_STABILIZATION = 0.5
-"""
-After airbrakes retract, it takes some time for the pressure to stabilize. DataProcessor will wait
-this amount of time before switching back to using pressure altitude.
 """
 
 # -------------------------------------------------------

--- a/airbrakes/context.py
+++ b/airbrakes/context.py
@@ -176,6 +176,28 @@ class AirbrakesContext:
             self.apogee_predictor_data_packets,
         )
 
+    def extend_airbrakes(self) -> None:
+        """
+        Extends the air brakes to the maximum extension.
+        """
+        self.servo.set_extended()
+
+    def retract_airbrakes(self) -> None:
+        """
+        Retracts the air brakes to the minimum extension.
+        """
+        self.servo.set_retracted()
+
+    def predict_apogee(self) -> None:
+        """
+        Predicts the apogee of the rocket based on the current processed data. This
+        should only be called in the coast state, before we start controlling the air brakes.
+        """
+        # Because the IMUDataProcessor only uses Estimated Data Packets to create Processor Data
+        # Packets, we only update the apogee predictor when Estimated Data Packets are ready.
+        if self.est_data_packets:
+            self.apogee_predictor.update(self.processor_data_packets)
+
     def generate_data_packets(self) -> None:
         """
         Generates the Context Data Packet and Servo Data Packet to be logged.
@@ -197,42 +219,3 @@ class AirbrakesContext:
             set_extension=str(self.servo.current_extension.value),
             encoder_position=self.servo.get_encoder_reading(),
         )
-
-    def extend_airbrakes(self) -> None:
-        """
-        Extends the air brakes to the maximum extension.
-        """
-        self.data_processor.prepare_for_extending_airbrakes()
-        self.servo.set_extended()
-
-    def retract_airbrakes(self) -> None:
-        """
-        Retracts the air brakes to the minimum extension.
-        """
-        self.servo.set_retracted()
-
-    def switch_altitude_back_to_pressure(self) -> None:
-        """
-        Switches the altitude back to pressure, after airbrakes have been retracted.
-        """
-        # This isn't in retract_airbrakes because we only want to call this after the airbrakes
-        # have been extended. We call retract_airbrakes at the beginning of every state, so we don't
-        # want this to be called every time.
-        self.data_processor.prepare_for_retracting_airbrakes()
-
-    def start_velocity_calibration(self) -> None:
-        """
-        Because we integrate for velocity, error can accumulate. This function starts the
-        calibration process for velocity.
-        """
-        self.data_processor.start_storing_altitude_data()
-
-    def predict_apogee(self) -> None:
-        """
-        Predicts the apogee of the rocket based on the current processed data. This
-        should only be called in the coast state, before we start controlling the air brakes.
-        """
-        # Because the IMUDataProcessor only uses Estimated Data Packets to create Processor Data
-        # Packets, we only update the apogee predictor when Estimated Data Packets are ready.
-        if self.est_data_packets:
-            self.apogee_predictor.update(self.processor_data_packets)

--- a/airbrakes/mock/display.py
+++ b/airbrakes/mock/display.py
@@ -177,9 +177,8 @@ class FlightDisplay:
 
         # Wait till we processed a data packet. This is to prevent the display from updating
         # before we have any data to display.
-        while True:
-            if self._context.data_processor._last_data_packet and self._context.context_data_packet:
-                break
+        while not self._context.data_processor._last_data_packet:
+            pass
 
         # Update the display as long as the program is running:
         while self._running:

--- a/airbrakes/state.py
+++ b/airbrakes/state.py
@@ -130,7 +130,6 @@ class CoastState(State):
     def __init__(self, context: "AirbrakesContext"):
         super().__init__(context)
         self.airbrakes_extended = False
-        self.context.start_velocity_calibration()
 
     def update(self):
         """Checks to see if the rocket has reached apogee, indicating the start of free fall."""
@@ -152,7 +151,6 @@ class CoastState(State):
             self.airbrakes_extended = True
         elif apogee <= TARGET_APOGEE_METERS and self.airbrakes_extended:
             self.context.retract_airbrakes()
-            self.context.switch_altitude_back_to_pressure()
             self.airbrakes_extended = False
 
         # if our velocity is zero or negative, we are in free fall.
@@ -176,10 +174,6 @@ class FreeFallState(State):
     """
 
     __slots__ = ()
-
-    def __init__(self, context: "AirbrakesContext"):
-        super().__init__(context)
-        self.context.switch_altitude_back_to_pressure()
 
     def update(self):
         """Check if the rocket has landed, based on our altitude and a spike in acceleration."""

--- a/airbrakes/telemetry/data_processor.py
+++ b/airbrakes/telemetry/data_processor.py
@@ -7,7 +7,6 @@ from scipy.spatial.transform import Rotation as R
 from airbrakes.constants import (
     ACCEL_DEADBAND_METERS_PER_SECOND_SQUARED,
     GRAVITY_METERS_PER_SECOND_SQUARED,
-    SECONDS_UNTIL_PRESSURE_STABILIZATION,
 )
 from airbrakes.telemetry.packets.imu_data_packet import EstimatedDataPacket
 from airbrakes.telemetry.packets.processor_data_packet import ProcessorDataPacket
@@ -26,16 +25,11 @@ class DataProcessor:
         "_current_orientation_quaternions",
         "_data_packets",
         "_initial_altitude",
-        "_integrating_for_altitude",
         "_last_data_packet",
         "_max_altitude",
         "_max_vertical_velocity",
-        "_previous_altitude",
-        "_previous_altitude_data_points",
         "_previous_vertical_velocity",
-        "_retraction_timestamp",
         "_rotated_accelerations",
-        "_store_altitude_data",
         "_time_differences",
         "_vertical_velocities",
     )
@@ -48,7 +42,6 @@ class DataProcessor:
         some of these values.
         """
         self._max_altitude: np.float64 = np.float64(0.0)
-        self._previous_altitude: np.float64 = np.float64(0.0)
         self._vertical_velocities: npt.NDArray[np.float64] = np.array([0.0])
         self._max_vertical_velocity: np.float64 = np.float64(0.0)
         self._previous_vertical_velocity: np.float64 = np.float64(0.0)
@@ -59,11 +52,15 @@ class DataProcessor:
         self._rotated_accelerations: npt.NDArray[np.float64] = np.array([0.0])
         self._data_packets: list[EstimatedDataPacket] = []
         self._time_differences: npt.NDArray[np.float64] = np.array([0.0])
-        self._integrating_for_altitude = False
-        # This a list of tuples with (timestamp in seconds, altitude)
-        self._previous_altitude_data_points: list[tuple[float, float]] = []
-        self._store_altitude_data = False
-        self._retraction_timestamp: float | None = None
+
+    def __str__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"max_altitude={self.max_altitude}, "
+            f"current_altitude={self.current_altitude}, "
+            f"velocity={self.vertical_velocity}, "
+            f"max_velocity={self.max_vertical_velocity}, "
+        )
 
     @property
     def max_altitude(self) -> float:
@@ -155,13 +152,6 @@ class DataProcessor:
         self._current_altitudes = self._calculate_current_altitudes()
         self._max_altitude = max(self._current_altitudes.max(), self._max_altitude)
 
-        if self._store_altitude_data:
-            # Stores the altitude data points for the quadratic fit
-            for i, data_packet in enumerate(data_packets):
-                self._previous_altitude_data_points.append(
-                    (convert_ns_to_s(data_packet.timestamp), float(self._current_altitudes[i]))
-                )
-
         # Store the last data point for the next update
         self._last_data_packet = data_packets[-1]
 
@@ -181,59 +171,6 @@ class DataProcessor:
             )
             for i in range(len(self._data_packets))
         ]
-
-    def start_storing_altitude_data(self) -> None:
-        """
-        Starts storing altitude data for the purpose of calibrating the velocity.
-        """
-        self._store_altitude_data = True
-
-    def prepare_for_extending_airbrakes(self) -> None:
-        """
-        When we extend the airbrakes, it messes with the pressure sensor which messes up the
-        altitude data. Additionally, the velocity data could have accumulated error due to the
-        strong acceleration from the motor burn. Because of these things, this function makes the
-        data processor start integrating for altitude and "calibrates" the velocity.
-        """
-        self._store_altitude_data = False
-        self._integrating_for_altitude = True
-
-        if len(self._previous_altitude_data_points) >= 3:
-            # First we have to only keep the data points with unique altitudes
-            data = np.array(self._previous_altitude_data_points)
-            # Makes numpy arrays
-            timestamps = data[:, 0]
-            altitudes = data[:, 1]
-
-            # Create a boolean mask that keeps the first point and every point where the altitude
-            # changes. Basically we're just keeping the points with unique altitudes.
-            mask = np.concatenate(([True], altitudes[1:] != altitudes[:-1]))
-            unique_timestamps = timestamps[mask]
-            unique_altitudes = altitudes[mask]
-
-            # Makes it so the first timestamp is 0 so the polyfit doesn't shit itself
-            first_timestamp = unique_timestamps[0]
-            shifted_timestamps = unique_timestamps - first_timestamp
-
-            # Fit a quadratic curve using the shifted timestamps
-            coeffs = np.polyfit(shifted_timestamps, unique_altitudes, 2)
-            altitude_fit = np.poly1d(coeffs)
-            velocity_fit = altitude_fit.deriv()
-
-            # This resets the vertical velocity to the value of the derivative of the quadratic
-            # fit at the current time. We do this because the velocity data could have accumulated
-            # error due to the strong acceleration from the motor burn.
-            self._previous_vertical_velocity = velocity_fit(
-                convert_ns_to_s(self.current_timestamp) - first_timestamp
-            )
-
-    def prepare_for_retracting_airbrakes(self) -> None:
-        """
-        After we retract airbrakes, we want to switch back to using pressure altitude, but we need
-        to wait a little bit of time for the pressure to stabilize.
-        """
-        self._integrating_for_altitude = False
-        self._retraction_timestamp = self.current_timestamp
 
     def _first_update(self) -> None:
         """
@@ -267,36 +204,16 @@ class DataProcessor:
 
     def _calculate_current_altitudes(self) -> npt.NDArray[np.float64]:
         """
-        Calculates the current altitudes, by zeroing out the initial altitude. It either uses the
-        altitude from the pressure sensor, or integrates acceleration for the altitude.
+        Calculates the current altitudes, by zeroing out the initial altitude.
         :return: A numpy array of the current altitudes of the rocket at each data point
         """
-        # While the airbrakes are extended, we integrate acceleration for the altitude rather than
-        # using the pressure sensor data. This is because the pressure sensor data is unreliable
-        # when the airbrakes are extended as the pressure gets fucky
-        if self._integrating_for_altitude or (
-            self._retraction_timestamp is not None
-            and convert_ns_to_s(self.current_timestamp - self._retraction_timestamp)
-            < SECONDS_UNTIL_PRESSURE_STABILIZATION
-        ):
-            # Integrate the vertical velocities to get altitudes:
-            # Start with the previous altitude and add the cumulative sum of (velocity * dt).
-            altitudes = self._previous_altitude + np.cumsum(
-                self._vertical_velocities * self._time_differences
-            )
-        else:
-            altitudes = np.array(
-                [
-                    data_packet.estPressureAlt - self._initial_altitude
-                    for data_packet in self._data_packets
-                ],
-            )
-
-        # Update the stored previous altitude for the next calculation.
-        self._previous_altitude = altitudes[-1]
-
         # Get the pressure altitudes from the data points and zero out the initial altitude
-        return altitudes
+        return np.array(
+            [
+                data_packet.estPressureAlt - self._initial_altitude
+                for data_packet in self._data_packets
+            ],
+        )
 
     def _calculate_rotated_accelerations(self) -> npt.NDArray[np.float64]:
         """

--- a/airbrakes/utils.py
+++ b/airbrakes/utils.py
@@ -28,15 +28,6 @@ def convert_ns_to_s(nanoseconds: float) -> float:
     return nanoseconds * 1e-9
 
 
-def convert_s_to_ns(seconds: float) -> float:
-    """
-    Converts seconds to nanoseconds.
-    :param seconds: The time in seconds.
-    :return: The time in nanoseconds.
-    """
-    return seconds * 1e9
-
-
 def set_process_priority(priority: int) -> None:
     """
     Sets the priority of the calling process to the specified nice value. Only works on Linux.

--- a/tests/auxil/launch_cases.py
+++ b/tests/auxil/launch_cases.py
@@ -201,7 +201,7 @@ class LaunchCase:
             self.landed_case.max_avg_vertical_acceleration
             >= LANDED_ACCELERATION_METERS_PER_SECOND_SQUARED
         )
-        test_cases["max_velocity"] = self.landed_case.max_velocity <= 3.0
+        test_cases["max_velocity"] = self.landed_case.max_velocity <= 0.1
         test_cases["min_altitude"] = self.landed_case.min_altitude <= GROUND_ALTITUDE_METERS
         test_cases["max_altitude"] = self.landed_case.max_altitude <= GROUND_ALTITUDE_METERS + 10.0
         test_cases["extensions"] = (

--- a/tests/test_components/test_data_processor.py
+++ b/tests/test_components/test_data_processor.py
@@ -10,7 +10,6 @@ import scipy.spatial
 
 from airbrakes.telemetry.data_processor import DataProcessor
 from airbrakes.telemetry.packets.imu_data_packet import EstimatedDataPacket
-from airbrakes.utils import convert_s_to_ns
 from tests.auxil.utils import make_est_data_packet
 
 
@@ -139,11 +138,6 @@ class TestDataProcessor:
         assert d._data_packets == []
         assert isinstance(d._time_differences, np.ndarray)
         assert list(d._time_differences) == [0.0]
-        assert d._integrating_for_altitude is False
-        assert d._previous_altitude == 0.0
-        assert d._previous_altitude_data_points == []
-        assert d._store_altitude_data is False
-        assert d._retraction_timestamp is None
 
         # Test properties on init
         assert d.max_altitude == 0.0
@@ -152,6 +146,12 @@ class TestDataProcessor:
         assert d.max_vertical_velocity == 0.0
         assert d.current_timestamp == 0
         assert d.average_vertical_acceleration == 0.0
+
+    def test_str(self, data_processor):
+        data_str = (
+            "DataProcessor(max_altitude=0.0, current_altitude=0.0, velocity=0.0, max_velocity=0.0, "
+        )
+        assert str(data_processor) == data_str
 
     def test_calculate_vertical_velocity(self, data_processor):
         """Tests whether the vertical velocity is correctly calculated"""
@@ -405,168 +405,6 @@ class TestDataProcessor:
         d.update(new_packets)
         assert d.current_altitude == current_altitude
         assert d._max_altitude == max_altitude
-
-    @pytest.mark.parametrize(
-        ("packets", "expected_velocity"),
-        [
-            # Test case 1: Using the function -(x-3)^2+9
-            (
-                [(1.0, 5.0), (2.0, 8.0), (3.0, 9.0)],
-                0.0,
-            ),
-            # Test case 2: Using the function -(x-5)^2+25
-            (
-                [(1.0, 10.0), (2.0, 17.0), (3.0, 22.0)],
-                4.0,
-            ),
-            # Test case 3: Using the function -(x-3)^2+9
-            (
-                [(1.0, 10.0), (2.0, 17.0), (3.0, 22.0), (7.0, 22.0)],
-                -4.0,
-            ),
-        ],
-        ids=["vel at apogee", "vel before apogee", "vel after apogee"],
-    )
-    def test_velocity_calibration(self, data_processor, packets, expected_velocity):
-        """
-        Tests whether the velocity is correctly calibrated and the altitude data points are stored
-        as expected.
-        """
-        d = data_processor
-
-        # Verify that altitude data storage is off initially.
-        assert not d._store_altitude_data
-
-        # Initialize with one packet at t=0.0, alt=0.0
-        d.update(
-            [
-                make_est_data_packet(
-                    timestamp=convert_s_to_ns(0.0),
-                    estPressureAlt=0.0,
-                )
-            ]
-        )
-        assert len(d._previous_altitude_data_points) == 0
-
-        # Start storing altitude data.
-        d.start_storing_altitude_data()
-        assert d._store_altitude_data
-
-        # Confirm the initial vertical velocity.
-        assert pytest.approx(d._previous_vertical_velocity) == 0.0
-
-        # Create and send the packets from the parameterized input.
-        packets_to_update = [
-            make_est_data_packet(timestamp=convert_s_to_ns(x), estPressureAlt=alt)
-            for x, alt in packets
-        ]
-        d.update(packets_to_update)
-
-        # Validate that the correct number of altitude data points were stored.
-        assert len(d._previous_altitude_data_points) == len(packets)
-        # Check that the first altitude value matches the expected value.
-        assert d._previous_altitude_data_points[0][1] == packets[0][1]
-
-        # After preparing for airbrakes, the vertical velocity should be reset to 0.
-        d.prepare_for_extending_airbrakes()
-        assert expected_velocity == pytest.approx(d._previous_vertical_velocity)
-
-    @pytest.mark.parametrize(
-        ("packets", "initial_altitude", "initial_velocity", "expected_altitudes"),
-        [
-            # Test case 1:
-            # Dummy packet at 1e9 ns, then two packets at 2e9 and 3e9.
-            # dt1 = 1.0 sec, dt2 = 1.0 sec.
-            # With a constant vertical velocity of 10 m/s,
-            # altitudes will be: [initial_altitude + 10*1, initial_altitude + 10*2]
-            (
-                [(2e9, -9.8, 105), (3e9, -9.8, 105)],
-                100.0,
-                10.0,
-                [110.0, 120.0],
-            ),
-            # Test case 2:
-            # Dummy packet at 1e9 ns, then three packets at 2e9, 2.5e9, and 3.5e9.
-            # dt1 = 1.0 sec, dt2 = 0.5 sec, dt3 = 1.0 sec.
-            # Altitude integration: [100+10*1, 100+10*1+10*0.5, 100+10*1+10*0.5+10*1]
-            # Expected altitudes: [110, 115, 125]
-            (
-                [(2e9, -9.8, 105), (2.5e9, -9.8, 105), (3.5e9, -9.8, 105)],
-                100.0,
-                10.0,
-                [110.0, 115.0, 125.0],
-            ),
-        ],
-    )
-    def test_calculate_altitude_integration(
-        self, data_processor, packets, initial_altitude, initial_velocity, expected_altitudes
-    ):
-        """
-        Tests whether altitude integration (using a simple Riemann sum of vertical velocity * dt)
-        is computed correctly when integrating for altitude is enabled.
-        """
-        d = data_processor
-
-        # Perform a dummy update to establish initial conditions.
-        # This avoids calling _first_update() during our test.
-        dummy_packet = EstimatedDataPacket(
-            timestamp=1e9,  # 1 second in ns
-            estCompensatedAccelX=0,
-            estCompensatedAccelY=0,
-            estCompensatedAccelZ=-9.8,  # so that rotated acceleration becomes 9.8 m/s²
-            estPressureAlt=100.0,
-            estOrientQuaternionW=1,
-            estOrientQuaternionX=0,
-            estOrientQuaternionY=0,
-            estOrientQuaternionZ=0,
-            estAngularRateX=0,
-            estAngularRateY=0,
-            estAngularRateZ=0,
-        )
-        d.update([dummy_packet])
-
-        # Set our known initial conditions.
-        d._previous_altitude = initial_altitude
-        d._previous_vertical_velocity = initial_velocity
-
-        # Force the altitude integration branch to run.
-        d._integrating_for_altitude = True
-
-        # Build new data packets based on the parameterized input.
-        # Each tuple is (timestamp, estCompensatedAccelZ, estPressureAlt).
-        # We use zero angular rates and identity orientation (quaternion = [1,0,0,0])
-        new_packets = []
-        for ts, accel_z, pressure_alt in packets:
-            new_packets.append(
-                EstimatedDataPacket(
-                    timestamp=ts,
-                    estCompensatedAccelX=0,
-                    estCompensatedAccelY=0,
-                    estCompensatedAccelZ=accel_z,
-                    estPressureAlt=pressure_alt,
-                    estOrientQuaternionW=1,
-                    estOrientQuaternionX=0,
-                    estOrientQuaternionY=0,
-                    estOrientQuaternionZ=0,
-                    estAngularRateX=0,
-                    estAngularRateY=0,
-                    estAngularRateZ=0,
-                )
-            )
-
-        # Update with the new packets.
-        d.update(new_packets)
-
-        # When integrating, the altitude is computed as:
-        #     altitude = previous_altitude + cumsum(vertical_velocity * dt)
-        # In our test, because the rotated acceleration comes out as 9.8 m/s²,
-        # deadband(9.8 - 9.8, ...) returns 0, so the vertical velocity remains constant.
-        # Thus, with a constant vertical velocity, altitude should increase linearly.
-        computed_altitudes = d._current_altitudes
-
-        # Compare each computed altitude with the expected value.
-        for computed, expected in zip(computed_altitudes, expected_altitudes, strict=False):
-            assert computed == pytest.approx(expected)
 
     def test_max_altitude(self, data_processor):
         """Tests whether the max altitude is correctly calculated even when altitude decreases"""


### PR DESCRIPTION
Reverts NCSU-High-Powered-Rocketry-Club/AirbrakesV2#173

Unfortunately this messes up Apogee Predictor for the pelicanator launch, the predicted apogee is 1320m when airbrakes deploy, which is very wrong. And the quad fit is over 50m off at apogee from pressure alt (which is okay since we switch back to pressure alt when airbrakes retract, but still)

Sorry @JacksonElia, maybe if we had time we could iron out the kinks. Maybe for next year? 