### PR TITLE
Changing Convergence Thresholds

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -334,7 +334,7 @@ CURVE_FIT_INITIAL = [-10.5, 0.03]
 APOGEE_PREDICTION_MIN_PACKETS = 10
 """The minimum number of processor data packets required to update the predicted apogee."""
 
-UNCERTAINTY_THRESHOLD = [0.0359, 0.00075]  # For near quick convergence times, use: [0.1, 0.75]
+UNCERTAINTY_THRESHOLD = [3, 0.001]  # For near quick convergence times, use: [0.1, 0.75]
 """
 The uncertainty from the curve fit, below which we will say that our apogee has converged. This
 uncertainty corresponds to being off by +/- 5m.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -435,7 +435,7 @@ class TestContext:
         context.start()
         time.sleep(0.01)
         # Need to assert that we have these many packets otherwise apogee prediction won't run:
-        assert context.imu.queued_imu_packets > APOGEE_PREDICTION_MIN_PACKETS
+        assert context.imu.queued_imu_packets >= APOGEE_PREDICTION_MIN_PACKETS
 
         # We have to do this convoluted manual way of updating instead of airbrakes.update() because
         # 1) faster-fifo does not guarantee that all packets will be fetched in a single get_many()


### PR DESCRIPTION
loosening the convergence thresholds improves both the accuracy of prediction and the convergence time. These values are fine-tuned for pelicanator launch 1 and 2, but also significantly improve prediction and convergence time on genesis launches and interest launch.