### PR TITLE
Add a JSON schema for `metadata.json`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-# Make sure that the additional_dependencies here match pyproject.toml
-
 # TODO: Uncomment the ci section and delete pre-commit.yml file after repo is public
 # ci:
 #   autofix_prs: false
@@ -27,3 +25,9 @@ repos:
         types: [python]
         pass_filenames: false
         description: Run ty static type checker
+  # Validate the metadata.json file against the JSON Schema
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.33.2
+    hooks:
+      - id: check-metaschema
+        files: metadata.json

--- a/launch_data/metadata.json
+++ b/launch_data/metadata.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "metadata_schema.json",
     "purple_launch.csv": {
         "date": "2023-12-16T17:11:35.000-05:00",
         "launch_site": {
@@ -8,7 +9,7 @@
             "wind_direction": "ESE",
             "location": "Bayboro, NC",
             "launch_coordinates": {
-                "latitiude": 35.1758000,
+                "latitude": 35.1758000,
                 "longitude": -76.8283400
             },
             "launch_rod_angle": 5.0
@@ -72,7 +73,7 @@
             "wind_direction": "S",
             "location": "Bayboro, NC",
             "launch_coordinates": {
-                "latitiude": 35.1758000,
+                "latitude": 35.1758000,
                 "longitude": -76.8283400
             },
             "launch_rod_angle": 6.0
@@ -105,7 +106,7 @@
             "wind_direction": "S",
             "location": "Bayboro, NC",
             "launch_coordinates": {
-                "latitiude": 35.1758000,
+                "latitude": 35.1758000,
                 "longitude": -76.8283400
             },
             "launch_rod_angle": 5.0
@@ -137,7 +138,7 @@
             "wind_direction": "N",
             "location": "Bayboro, NC",
             "launch_coordinates": {
-                "latitiude": 35.1757368,
+                "latitude": 35.1757368,
                 "longitude": -76.8282710
             },
             "launch_rod_angle": 2.0
@@ -246,7 +247,7 @@
         "flight_data": {
             "log_buffer_index": 5000,
             "apogee_meters": 1090.16,
-            "landed_coordinates:": {
+            "landed_coordinates": {
                 "latitude": 34.04811560103679,
                 "longitude": -80.42347345289595
             },
@@ -265,7 +266,7 @@
             "wind_direction": "SW",
             "location": "Bayboro, NC",
             "launch_coordinates": {
-                "latitiude": 35.1762107,
+                "latitude": 35.1762107,
                 "longitude": -76.8293647
             },
             "launch_rod_angle": 5.0
@@ -297,7 +298,7 @@
             "wind_direction": "NW",
             "location": "Bragg Farms, AL",
             "launch_coordinates": {
-                "latitiude": 34.894610,
+                "latitude": 34.894610,
                 "longitude": -86.616470
             },
             "launch_rod_angle": 5.0

--- a/launch_data/metadata_schema.json
+++ b/launch_data/metadata_schema.json
@@ -1,0 +1,132 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "date": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "launch_site": {
+                "type": "object",
+                "properties": {
+                    "air_temperature_celsius": {
+                        "type": "number"
+                    },
+                    "air_pressure_mb": {
+                        "type": "number"
+                    },
+                    "wind_speed_kmh": {
+                        "type": "number"
+                    },
+                    "wind_direction": {
+                        "type": "string"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "launch_coordinates": {
+                        "type": "object",
+                        "properties": {
+                            "latitude": {
+                                "type": ["number", "null"]
+                            },
+                            "longitude": {
+                                "type": ["number", "null"]
+                            }
+                        },
+                        "required": ["latitude", "longitude"],
+                        "additionalProperties": false
+                    },
+                    "launch_rod_angle": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "air_temperature_celsius",
+                    "air_pressure_mb",
+                    "wind_speed_kmh",
+                    "wind_direction",
+                    "location",
+                    "launch_coordinates",
+                    "launch_rod_angle"
+                ],
+                "additionalProperties": false
+            },
+            "imu_details": {
+                "type": "object",
+                "properties": {
+                    "imu_model": {
+                        "type": "string"
+                    },
+                    "raw_packet_frequency": {
+                        "type": "number"
+                    },
+                    "est_packet_frequency": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "imu_model",
+                    "raw_packet_frequency",
+                    "est_packet_frequency"
+                ],
+                "additionalProperties": false
+            },
+            "flight_data": {
+                "type": "object",
+                "properties": {
+                    "log_buffer_index": {
+                        "type": "integer"
+                    },
+                    "apogee_meters": {
+                        "type": ["number", "null"]
+                    },
+                    "landed_coordinates": {
+                        "type": "object",
+                        "properties": {
+                            "latitude": {
+                                "type": ["number", "null"]
+                            },
+                            "longitude": {
+                                "type": ["number", "null"]
+                            }
+                        },
+                        "required": ["latitude", "longitude"],
+                        "additionalProperties": false
+                    },
+                    "flight_length_seconds": {
+                        "type": "number"
+                    },
+                    "target_apogee_meters": {
+                        "type": "number"
+                    },
+                    "landed_coordinates_precision": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "required": [
+                    "log_buffer_index",
+                    "apogee_meters",
+                    "landed_coordinates",
+                    "flight_length_seconds",
+                    "target_apogee_meters",
+                    "landed_coordinates_precision"
+                ],
+                "additionalProperties": false
+            },
+            "flight_description": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "date",
+            "launch_site",
+            "imu_details",
+            "flight_data",
+            "flight_description"
+        ],
+        "additionalProperties": false
+    }
+}


### PR DESCRIPTION
I apparently can't spell `latitude`. This PR adds a json schema in both the metadata.json (for IDE warnings) and as a pre-commit hook. So nobody can mess it up hopefully.

schema generated by Grok. There is a new schema version `2020-12` available, but VSCode doesn't like it apparently idk. 

(don't mind failing unit tests, I need to fix that on the base branch)
