### PR TITLE
Do not allow running legacy launch 2

### DIFF
--- a/airbrakes/mock/mock_imu.py
+++ b/airbrakes/mock/mock_imu.py
@@ -69,6 +69,11 @@ class MockIMU(BaseIMU):
             root_dir = Path(__file__).parent.parent.parent
             log_file_path = next(iter(Path(root_dir / "launch_data").glob("*.csv")))
 
+        self._log_file_path: Path = typing.cast("Path", log_file_path)
+
+        if self._log_file_path == Path("launch_data/legacy_launch_2.csv"):
+            raise ValueError("There is no data for this flight, please choose another file.")
+
         # If it's not a real time replay, we limit how big the queue gets when doing an integration
         # test, because we read the file much faster than update(), sometimes resulting thousands
         # of data packets in the queue, which will obviously mess up data processing calculations.
@@ -83,8 +88,6 @@ class MockIMU(BaseIMU):
             args=(real_time_replay, start_after_log_buffer),
             name="Mock IMU Process",
         )
-
-        self._log_file_path: Path = typing.cast("Path", log_file_path)
 
         # If we ever switch back to using "fork", the below line should be moved into `_read_csv`.
         self._headers: list[str] = pl.scan_csv(self._log_file_path).collect_schema().names()

--- a/tests/test_hardware/test_imu.py
+++ b/tests/test_hardware/test_imu.py
@@ -1,15 +1,17 @@
 import multiprocessing
 import multiprocessing.context
-import multiprocessing.sharedctypes
 import signal
 import time
 from collections import deque
 from ctypes import c_byte, c_int
+from pathlib import Path
 
 import faster_fifo
+import pytest
 
 from airbrakes.constants import IMU_PORT
 from airbrakes.hardware.imu import IMU
+from airbrakes.mock.mock_imu import MockIMU
 from airbrakes.telemetry.packets.imu_data_packet import (
     EstimatedDataPacket,
     IMUDataPacket,
@@ -99,6 +101,10 @@ class TestIMU:
         assert isinstance(imu.queued_imu_packets, int)
         assert isinstance(imu._imu_packets_per_cycle, c_int)
         assert isinstance(imu.imu_packets_per_cycle, int)
+
+        # Test Legacy Launch 2 exception:
+        with pytest.raises(ValueError, match="There is no data for this flight"):
+            MockIMU(False, log_file_path=Path("launch_data/legacy_launch_2.csv"))
 
     def test_imu_start(self):
         """


### PR DESCRIPTION
Running a mock with that flight errors out with a `polars` exception, so we handle that before and say why we can't use that flight.