### PR TITLE
Remove dead dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ dependencies = [
     # Pinned versions because we need python 3.14 free threading wheels:
     "polars==1.36.1",
     "polars-runtime-32",
-    # Need the below to get the servo to work. Make sure you are using the full Raspberry Pi OS
-    # 64 bit image and not the lite. You also need to add `dtparam=i2c_arm=on` in the /boot/firmware/config.txt
-    "rpi-gpio>=0.7.1",
     # Please see library docs for usage and installation on the Pi 4/5. You need to add
     # `dtoverlay=pwm-2chan` in /boot/firmware/config.txt.
     "rpi-hardware-pwm>=0.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,6 @@ dependencies = [
     { name = "polars-runtime-32", version = "1.36.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
     { name = "polars-runtime-32", version = "1.36.1", source = { url = "https://github.com/harshil21/polars-runtime-32-ft/raw/refs/heads/main/wheels/polars_runtime_32-1.36.1-cp314-cp314t-manylinux_2_39_aarch64.whl" }, marker = "platform_machine == 'aarch64'" },
     { name = "polars-runtime-32", version = "1.36.1", source = { url = "https://github.com/harshil21/polars-runtime-32-ft/raw/refs/heads/main/wheels/polars_runtime_32-1.36.1-cp314-cp314t-manylinux_2_39_x86_64.whl" }, marker = "platform_machine == 'x86_64'" },
-    { name = "rpi-gpio" },
     { name = "rpi-hardware-pwm" },
     { name = "scipy" },
     { name = "textual" },
@@ -63,7 +62,6 @@ requires-dist = [
     { name = "polars-runtime-32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
     { name = "polars-runtime-32", marker = "platform_machine == 'aarch64'", url = "https://github.com/harshil21/polars-runtime-32-ft/raw/refs/heads/main/wheels/polars_runtime_32-1.36.1-cp314-cp314t-manylinux_2_39_aarch64.whl" },
     { name = "polars-runtime-32", marker = "platform_machine == 'x86_64'", url = "https://github.com/harshil21/polars-runtime-32-ft/raw/refs/heads/main/wheels/polars_runtime_32-1.36.1-cp314-cp314t-manylinux_2_39_x86_64.whl" },
-    { name = "rpi-gpio", specifier = ">=0.7.1" },
     { name = "rpi-hardware-pwm", specifier = ">=0.3.0" },
     { name = "scipy" },
     { name = "swig", marker = "extra == 'encoder'", specifier = ">=4.3.0" },
@@ -526,12 +524,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
 ]
-
-[[package]]
-name = "rpi-gpio"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/0f/10b524a12b3445af1c607c27b2f5ed122ef55756e29942900e5c950735f2/RPi.GPIO-0.7.1.tar.gz", hash = "sha256:cd61c4b03c37b62bba4a5acfea9862749c33c618e0295e7e90aa4713fb373b70", size = 29090, upload-time = "2022-02-06T15:15:06.022Z" }
 
 [[package]]
 name = "rpi-hardware-pwm"


### PR DESCRIPTION
Removes `rpi-gpio` as a dependency. We only used this when we had 2 servos with the servo driver. 

Merge after #276 