### PR TITLE
Disallow packages newer than last 7 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ build-backend = "hatchling.build"
 
 # UV:
 [tool.uv]
+exclude-newer = "7 days"
+exclude-newer-package = { firm-client = "1 second", hprm = "1 second" }
 python-preference = "only-managed"
 
 # HATCH:

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,14 @@ resolution-markers = [
     "platform_machine != 'AMD64' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-03-25T02:06:22.303347111Z"
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+hprm = { timestamp = "2026-04-01T02:06:21.303362223Z", span = "PT1S" }
+firm-client = { timestamp = "2026-04-01T02:06:21.303352659Z", span = "PT1S" }
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
As you all might be aware, the recent supply chain attacks through PyPI and npm have been crazy. We should follow good security practices and disallow packages which are newer than the last 7 days. 

In house packages like `firm-client` and `hprm` are excluded from this constraint. I expect the same level of auditing for the dependencies of those packages.