### PR TITLE
Add control of servo switch for Airbender v0.3

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -103,6 +103,16 @@ I2C_BUS = 1
 The I2C bus the sensor is connected to on the Raspberry Pi.
 """
 
+CHIP_PATH = "/dev/gpiochip0"
+"""
+The GPIO bus we want to control for the servo
+"""
+
+SERVO_SWITCH_PIN = 26
+"""
+The GPIO pin which controls the servo switch which is wired via Airbender
+"""
+
 # -------------------------------------------------------
 # Encoder Configuration
 # -------------------------------------------------------

--- a/airbrakes/hardware/servo.py
+++ b/airbrakes/hardware/servo.py
@@ -4,15 +4,18 @@ controls the extension of the airbrakes, along with a rotary encoder to measure
 the servo's position.
 """
 
+import gpiod
 import gpiozero
 from rpi_hardware_pwm import HardwarePWM
 
 from airbrakes.base_classes.base_servo import BaseServo
 from airbrakes.constants import (
+    CHIP_PATH,
     I2C_ADDRESS,
     I2C_BUS,
     MAX_EXPECTED_AMPS,
     SERVO_OPERATING_FREQUENCY_HZ,
+    SERVO_SWITCH_PIN,
     SHUNT_OHMS,
     ServoExtension,
 )
@@ -31,7 +34,7 @@ class Servo(BaseServo):
     on the Pi 5.
     """
 
-    __slots__ = ()
+    __slots__ = ("servo_line",)
 
     def __init__(
         self,
@@ -49,6 +52,13 @@ class Servo(BaseServo):
         :param encoder_pin_number_b: The GPIO pin that the signal wire B
             of the encoder is connected to.
         """
+        # Request control of a GPIO pin from the kernel
+        self.servo_line = gpiod.request_lines(
+            path=CHIP_PATH,
+            consumer="airbrakes-servo",
+            config={SERVO_SWITCH_PIN: gpiod.LineSettings(direction=gpiod.line.Direction.OUTPUT)},
+        )
+
         servo = HardwarePWM(pwm_channel=servo_channel, hz=SERVO_OPERATING_FREQUENCY_HZ, chip=0)
 
         # This library can only be imported on the raspberry pi. It's why the import is here.
@@ -82,12 +92,18 @@ class Servo(BaseServo):
         Starts the servo by starting the PWM signal with the initial duty cycle
         corresponding to the minimum extension with no buzzing.
         """
+        # Switch on the servo switch
+        self.servo_line.set_value(SERVO_SWITCH_PIN, gpiod.line.Value.ACTIVE)
+
         self.servo.start(self._angle_to_duty_cycle(ServoExtension.MIN_NO_BUZZ.value))
 
     def stop(self) -> None:
         """
         Stops the servo by stopping the PWM signal.
         """
+        # Switch off the servo switch
+        self.servo_line.set_value(SERVO_SWITCH_PIN, gpiod.line.Value.INACTIVE)
+
         self.servo.stop()
 
     def get_battery_volts(self) -> float:

--- a/airbrakes/hardware/servo.py
+++ b/airbrakes/hardware/servo.py
@@ -4,7 +4,13 @@ controls the extension of the airbrakes, along with a rotary encoder to measure
 the servo's position.
 """
 
-import gpiod
+import contextlib
+
+# Can only be imported on Linux:
+with contextlib.suppress(ImportError):
+    import gpiod
+
+
 import gpiozero
 from rpi_hardware_pwm import HardwarePWM
 
@@ -105,6 +111,9 @@ class Servo(BaseServo):
         self.servo_line.set_value(SERVO_SWITCH_PIN, gpiod.line.Value.INACTIVE)
 
         self.servo.stop()
+
+        # Release the gpio pin back to the kernel
+        self.servo_line.release()
 
     def get_battery_volts(self) -> float:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "hprm>=0.1.7",
     "firm-client>=1.2.2",
     "pi-ina219>=1.4.1",
-    "gpiod>=2.4.2",
+    "gpiod>=2.4.2; platform_system == 'Linux'",
 ]
 
 # TODO: Remove this once polars has official wheels for python 3.14t

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "hprm>=0.1.7",
     "firm-client>=1.2.2",
     "pi-ina219>=1.4.1",
+    "gpiod>=2.4.2",
 ]
 
 # TODO: Remove this once polars has official wheels for python 3.14t

--- a/uv.lock
+++ b/uv.lock
@@ -17,12 +17,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T04:21:13.693747574Z"
+exclude-newer = "2026-04-11T05:03:40.755416519Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-hprm = { timestamp = "2026-04-18T04:21:12.693766111Z", span = "PT1S" }
-firm-client = { timestamp = "2026-04-18T04:21:12.693757222Z", span = "PT1S" }
+hprm = { timestamp = "2026-04-18T05:03:39.755437093Z", span = "PT1S" }
+firm-client = { timestamp = "2026-04-18T05:03:39.755427519Z", span = "PT1S" }
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -116,7 +116,7 @@ source = { editable = "." }
 dependencies = [
     { name = "colorama" },
     { name = "firm-client" },
-    { name = "gpiod" },
+    { name = "gpiod", marker = "sys_platform == 'linux'" },
     { name = "gpiozero" },
     { name = "hprm" },
     { name = "msgspec" },
@@ -162,7 +162,7 @@ profiling = [
 requires-dist = [
     { name = "colorama" },
     { name = "firm-client", specifier = ">=1.2.2" },
-    { name = "gpiod", specifier = ">=2.4.2" },
+    { name = "gpiod", marker = "sys_platform == 'linux'", specifier = ">=2.4.2" },
     { name = "gpiozero" },
     { name = "hprm", specifier = ">=0.1.7" },
     { name = "lgpio", marker = "extra == 'encoder'", specifier = ">=0.2.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -17,12 +17,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T16:05:18.898646782Z"
+exclude-newer = "2026-04-11T04:21:13.693747574Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-hprm = { timestamp = "2026-04-15T16:05:17.898667364Z", span = "PT1S" }
-firm-client = { timestamp = "2026-04-15T16:05:17.898657399Z", span = "PT1S" }
+hprm = { timestamp = "2026-04-18T04:21:12.693766111Z", span = "PT1S" }
+firm-client = { timestamp = "2026-04-18T04:21:12.693757222Z", span = "PT1S" }
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -116,6 +116,7 @@ source = { editable = "." }
 dependencies = [
     { name = "colorama" },
     { name = "firm-client" },
+    { name = "gpiod" },
     { name = "gpiozero" },
     { name = "hprm" },
     { name = "msgspec" },
@@ -161,6 +162,7 @@ profiling = [
 requires-dist = [
     { name = "colorama" },
     { name = "firm-client", specifier = ">=1.2.2" },
+    { name = "gpiod", specifier = ">=2.4.2" },
     { name = "gpiozero" },
     { name = "hprm", specifier = ">=0.1.7" },
     { name = "lgpio", marker = "extra == 'encoder'", specifier = ">=0.2.2.0" },
@@ -333,6 +335,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "gpiod"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/ca/b3bd043091b4462d6c5561f86581f553df102d8990c37938ddbff2823016/gpiod-2.4.2.tar.gz", hash = "sha256:602aae17ff365bb8e2a30ce65c6bbf2d8e7a7e64bf016e82e4fd4c730ef69ab7", size = 68330, upload-time = "2026-04-09T09:13:10.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c5/a19b7991d6da899e5715e209f99e0a8a96722e1add23a5616f67e2b2ccd8/gpiod-2.4.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7a327a0f5e3fb6f6b72b55aea3ada7e7d179337559a403cabc6e18ccb670d1d", size = 114822, upload-time = "2026-04-09T09:12:58.534Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ca/a253dc5cdb9e5d5a19a964cf3c12eb63d06ec98d01341cb05e7a090e38fb/gpiod-2.4.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00839630503fae47157c7a4c163d0c43f33af9bea48e425bb3b1cf2883cdf529", size = 114534, upload-time = "2026-04-09T09:12:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/19/55adbbea2a3ff787300ceea155bc98bb556ab68e9c4af75d8b7ac8552554/gpiod-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f5e264b0601e15c5de2b7ebfec3a8159f18a86c74e95ce0930dd7e866ce86cae", size = 113056, upload-time = "2026-04-09T09:13:01.285Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/5440b27e16c5b925d4484d082c4acebb2d8081b483a0bc4d4591e020aad0/gpiod-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e588cf9f361def5515bdb40a58280be58e5dca805a42de8780c5febc7b5cb9c", size = 113111, upload-time = "2026-04-09T09:13:02.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a little bit of code to enable and disable the servo automatically during startup/shutdown if we're going to use Airbender v0.3. 

If we are using Airbender v0.3, then we should either merge this, OR add another checklist item on the pad which enables the servo via the command: `pinctrl set 26 op dh` (sets gpio 26 as output, and drives it high)

Mocks unaffected.