### PR TITLE
Switching apogee prediciton from 1DOF to 3DOF

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -1,6 +1,5 @@
 """Contains the constants used in the Airbrakes module."""
 
-import math
 from enum import Enum, StrEnum
 from pathlib import Path
 
@@ -258,9 +257,10 @@ ROCKET_DRY_MASS_KG: float = ROCKET_WET_MASS_KG - PROPELLANT_MASS_KG
 ROCKET_CD: float = 0.393
 """The drag coefficient of the rocket with airbrakes all the way retracted."""
 
-# This is the diameter of the rocket in inches converted to meters, turned into radius, then used to
-# calculate cross-sectional area.
-ROCKET_CROSS_SECTIONAL_AREA_M2: float = math.pi * (6.0 * 0.0254 / 2) ** 2
+ROCKET_DIAMETER_M: float = 6.0 * 0.0254
+"""The diameter of the rocket in meters, with airbrakes all the way retracted."""
+
+ROCKET_CROSS_SECTIONAL_AREA_M2: float = 0.0182414692475
 """The cross-sectional area of the rocket in square meters, with airbrakes all
 the way retracted."""
 
@@ -270,10 +270,7 @@ ROCKET_MOMENT_OF_INERTIA_KG_M2: float = 11.45
 ROCKET_STAB_MARGIN_CAL: float = 3.24
 """The stability margin of the rocket measured in calipers"""
 
-ROCKET_STAB_MARGIN_DIMENSIONAL_M: float = ROCKET_STAB_MARGIN_CAL * (6.0 * 0.0254)
-"""The static stability margin of the rocket in meters"""
-
-# TODO: Verify CL_A with aerodynamic analysis.
+# TODO: Need to verify with aerodynamic analysis.
 ROCKET_CL_A: float = 0.2
 """The lift curve slope of the rocket"""
 

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -268,7 +268,7 @@ ROCKET_MOMENT_OF_INERTIA_KG_M2: float = 11.45
 """The moment of inertia of the rocket in kg * m^2, with airbrakes all the way retracted."""
 
 ROCKET_STAB_MARGIN_CAL: float = 3.24
-"""The stability margin of the rocket measured in calipers"""
+"""The stability margin of the rocket measured in calibers"""
 
 # TODO: Need to verify with aerodynamic analysis.
 ROCKET_CL_A: float = 0.2

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -264,12 +264,6 @@ ROCKET_CROSS_SECTIONAL_AREA_M2: float = math.pi * (6.0 * 0.0254 / 2) ** 2
 """The cross-sectional area of the rocket in square meters, with airbrakes all
 the way retracted."""
 
-ROCKET_AREA_DRAG_M2: float = ROCKET_CROSS_SECTIONAL_AREA_M2
-"""The aerodynamic reference area used by HPRM when computing drag forces."""
-
-ROCKET_AREA_LIFT_M2: float = ROCKET_CROSS_SECTIONAL_AREA_M2
-"""The aerodynamic reference area used by HPRM when computing lift forces."""
-
 ROCKET_MOMENT_OF_INERTIA_KG_M2: float = 11.45
 """The moment of inertia of the rocket in kg * m^2, with airbrakes all the way retracted."""
 
@@ -280,7 +274,7 @@ ROCKET_STAB_MARGIN_DIMENSIONAL_M: float = ROCKET_STAB_MARGIN_CAL * (6.0 * 0.0254
 """The static stability margin of the rocket in meters"""
 
 # TODO: Verify CL_A with aerodynamic analysis.
-ROCKET_CL_A: float = 0.2 
+ROCKET_CL_A: float = 0.2
 """The lift curve slope of the rocket"""
 
 # ----------------------------------------

--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -264,6 +264,25 @@ ROCKET_CROSS_SECTIONAL_AREA_M2: float = math.pi * (6.0 * 0.0254 / 2) ** 2
 """The cross-sectional area of the rocket in square meters, with airbrakes all
 the way retracted."""
 
+ROCKET_AREA_DRAG_M2: float = ROCKET_CROSS_SECTIONAL_AREA_M2
+"""The aerodynamic reference area used by HPRM when computing drag forces."""
+
+ROCKET_AREA_LIFT_M2: float = ROCKET_CROSS_SECTIONAL_AREA_M2
+"""The aerodynamic reference area used by HPRM when computing lift forces."""
+
+ROCKET_MOMENT_OF_INERTIA_KG_M2: float = 11.45
+"""The moment of inertia of the rocket in kg * m^2, with airbrakes all the way retracted."""
+
+ROCKET_STAB_MARGIN_CAL: float = 3.24
+"""The stability margin of the rocket measured in calipers"""
+
+ROCKET_STAB_MARGIN_DIMENSIONAL_M: float = ROCKET_STAB_MARGIN_CAL * (6.0 * 0.0254)
+"""The static stability margin of the rocket in meters"""
+
+# TODO: Verify CL_A with aerodynamic analysis.
+ROCKET_CL_A: float = 0.2 
+"""The lift curve slope of the rocket"""
+
 # ----------------------------------------
 # Data Processor Configuration
 # ----------------------------------------

--- a/airbrakes/data_handling/apogee_predictor.py
+++ b/airbrakes/data_handling/apogee_predictor.py
@@ -1,10 +1,11 @@
 """Module for predicting apogee."""
 
+import math
 import queue
 import threading
 from typing import TYPE_CHECKING, Literal, cast
 
-from hprm import AdaptiveTimeStep, ModelType, OdeMethod, Rocket
+from hprm import InitialState3DOF, OdeMethod, Rocket
 
 from airbrakes import constants
 from airbrakes.constants import (
@@ -120,12 +121,11 @@ class ApogeePredictor:
         rocket = Rocket(
             constants.ROCKET_DRY_MASS_KG,
             constants.ROCKET_CD,
-            constants.ROCKET_CROSS_SECTIONAL_AREA_M2,
-            # Rest of these are unused for 1D modeling
-            0.0,
-            0.0,
-            0.0,
-            0.0,
+            constants.ROCKET_AREA_DRAG_M2,
+            constants.ROCKET_AREA_LIFT_M2,
+            constants.ROCKET_MOMENT_OF_INERTIA_KG_M2,
+            constants.ROCKET_STAB_MARGIN_DIMENSIONAL_M,
+            constants.ROCKET_CL_A,
         )
 
         # Keep checking for new data packets until the stop signal is received:
@@ -140,18 +140,31 @@ class ApogeePredictor:
 
             most_recent_packet = cast("ProcessorDataPacket", processor_data_packets[-1])
 
-            adaptive_time_step = AdaptiveTimeStep.default()
-            adaptive_time_step.dt_max = 1
-
             # Compute apogee given the latest state and history
 
-            apogee = rocket.predict_apogee(
-                most_recent_packet.current_altitude,
-                most_recent_packet.vertical_velocity,
-                ModelType.OneDOF,
-                OdeMethod.RK45,
-                adaptive_time_step,
+            initial_state = InitialState3DOF(
+                x=0.0,
+                y=most_recent_packet.current_altitude,
+                angle=math.radians(most_recent_packet.tilt_angle_degrees),
+                vx=most_recent_packet.horizontal_velocity,
+                vy=most_recent_packet.vertical_velocity,
+                angular_rate=most_recent_packet.angular_rate,
+                )
+
+            apogee = rocket.predict_apogee_3dof(
+                initial_state,
+                integration_method=OdeMethod.RK45,
             )
+
+            # To view relevant data from the processor data packet, only to help implement 3DOF and
+            # see where things might be going wrong.
+            print(
+                    f"tilt={most_recent_packet.tilt_angle_degrees:.2f}°, "
+                    f"vx={most_recent_packet.horizontal_velocity:.2f} m/s, "
+                    f"vy={most_recent_packet.vertical_velocity:.2f} m/s, "
+                    f"angular_rate={most_recent_packet.angular_rate:.2f}, "
+                    f"apogee={apogee:.2f} m"
+                )
 
             # Push a prediction packet back to the main thread.
             # TODO: add more stuff to the packet

--- a/airbrakes/data_handling/apogee_predictor.py
+++ b/airbrakes/data_handling/apogee_predictor.py
@@ -149,7 +149,7 @@ class ApogeePredictor:
                 angle=math.radians(most_recent_packet.tilt_angle_degrees),
                 vx=most_recent_packet.horizontal_velocity_meters_per_s,
                 vy=most_recent_packet.vertical_velocity_meters_per_s,
-                angular_rate=most_recent_packet.angular_rate_deg_per_s,
+                angular_rate=math.radians(most_recent_packet.angular_rate_deg_per_s),
             )
 
             apogee = rocket.predict_apogee_3dof(

--- a/airbrakes/data_handling/apogee_predictor.py
+++ b/airbrakes/data_handling/apogee_predictor.py
@@ -115,10 +115,8 @@ class ApogeePredictor:
         """
         Responsible for fetching data packets, updating internal state, and
         finally predicting the apogee using the chosen method (e.g. HPRM).
-
         Runs in a separate thread.
         """
-
         stability_margin_m = constants.ROCKET_STAB_MARGIN_CAL * constants.ROCKET_DIAMETER_M
 
         rocket = Rocket(
@@ -152,7 +150,7 @@ class ApogeePredictor:
                 vx=most_recent_packet.horizontal_velocity_meters_per_s,
                 vy=most_recent_packet.vertical_velocity_meters_per_s,
                 angular_rate=most_recent_packet.angular_rate_deg_per_s,
-                )
+            )
 
             apogee = rocket.predict_apogee_3dof(
                 initial_state,
@@ -167,6 +165,6 @@ class ApogeePredictor:
                     most_recent_packet.vertical_velocity_meters_per_s,
                     most_recent_packet.horizontal_velocity_meters_per_s,
                     most_recent_packet.tilt_angle_degrees,
-                    most_recent_packet.angular_rate_deg_per_s
+                    most_recent_packet.angular_rate_deg_per_s,
                 )
             )

--- a/airbrakes/data_handling/apogee_predictor.py
+++ b/airbrakes/data_handling/apogee_predictor.py
@@ -121,8 +121,8 @@ class ApogeePredictor:
         rocket = Rocket(
             constants.ROCKET_DRY_MASS_KG,
             constants.ROCKET_CD,
-            constants.ROCKET_AREA_DRAG_M2,
-            constants.ROCKET_AREA_LIFT_M2,
+            constants.ROCKET_CROSS_SECTIONAL_AREA_M2,
+            constants.ROCKET_CROSS_SECTIONAL_AREA_M2,
             constants.ROCKET_MOMENT_OF_INERTIA_KG_M2,
             constants.ROCKET_STAB_MARGIN_DIMENSIONAL_M,
             constants.ROCKET_CL_A,
@@ -146,9 +146,9 @@ class ApogeePredictor:
                 x=0.0,
                 y=most_recent_packet.current_altitude,
                 angle=math.radians(most_recent_packet.tilt_angle_degrees),
-                vx=most_recent_packet.horizontal_velocity,
-                vy=most_recent_packet.vertical_velocity,
-                angular_rate=most_recent_packet.angular_rate,
+                vx=most_recent_packet.horizontal_velocity_meters_per_s,
+                vy=most_recent_packet.vertical_velocity_meters_per_s,
+                angular_rate=most_recent_packet.angular_rate_deg_per_s,
                 )
 
             apogee = rocket.predict_apogee_3dof(
@@ -156,22 +156,14 @@ class ApogeePredictor:
                 integration_method=OdeMethod.RK45,
             )
 
-            # To view relevant data from the processor data packet, only to help implement 3DOF and
-            # see where things might be going wrong.
-            print(
-                    f"tilt={most_recent_packet.tilt_angle_degrees:.2f}°, "
-                    f"vx={most_recent_packet.horizontal_velocity:.2f} m/s, "
-                    f"vy={most_recent_packet.vertical_velocity:.2f} m/s, "
-                    f"angular_rate={most_recent_packet.angular_rate:.2f}, "
-                    f"apogee={apogee:.2f} m"
-                )
-
             # Push a prediction packet back to the main thread.
-            # TODO: add more stuff to the packet
             self._apogee_predictor_packet_queue.put(
                 ApogeePredictorDataPacket(
                     apogee,
                     most_recent_packet.current_altitude,
-                    most_recent_packet.vertical_velocity,
+                    most_recent_packet.vertical_velocity_meters_per_s,
+                    most_recent_packet.horizontal_velocity_meters_per_s,
+                    most_recent_packet.tilt_angle_degrees,
+                    most_recent_packet.angular_rate_deg_per_s
                 )
             )

--- a/airbrakes/data_handling/apogee_predictor.py
+++ b/airbrakes/data_handling/apogee_predictor.py
@@ -118,13 +118,16 @@ class ApogeePredictor:
 
         Runs in a separate thread.
         """
+
+        stability_margin_m = constants.ROCKET_STAB_MARGIN_CAL * constants.ROCKET_DIAMETER_M
+
         rocket = Rocket(
             constants.ROCKET_DRY_MASS_KG,
             constants.ROCKET_CD,
             constants.ROCKET_CROSS_SECTIONAL_AREA_M2,
             constants.ROCKET_CROSS_SECTIONAL_AREA_M2,
             constants.ROCKET_MOMENT_OF_INERTIA_KG_M2,
-            constants.ROCKET_STAB_MARGIN_DIMENSIONAL_M,
+            stability_margin_m,
             constants.ROCKET_CL_A,
         )
 

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -243,7 +243,6 @@ class DataProcessor:
         # Get the pressure altitudes from the data points and zero out the initial altitude
         return altitudes
 
-
     def _calculate_time_differences(self) -> npt.NDArray[np.float64]:
         """
         Calculates the time difference between each data packet and the previous data packet.

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -243,15 +243,6 @@ class DataProcessor:
         # Get the pressure altitudes from the data points and zero out the initial altitude
         return altitudes
 
-    def _calculate_horizontal_velocity(self, vertical_velocity: float, tilt_angle_degrees: float,) -> float:
-        """
-        Calculates the horizontal velocity from the rocket's vertical velocity and tilt tilt angle.
-        """
-        angle_radians = np.radians(tilt_angle_degrees)
-        horizontal_velocity = vertical_velocity * np.tan(angle_radians)
-
-        # Get the current horizontal velocity
-        return horizontal_velocity
 
     def _calculate_time_differences(self) -> npt.NDArray[np.float64]:
         """
@@ -285,16 +276,18 @@ class DataProcessor:
         packets most recently passed in by update()
         :return: A list of ProcessorDataPacket objects.
         """
+        # TODO: Horizontal velocity is currently unavailable. Using an estimate of 0 m/s until a
+        # proper estimate of the velocity magnitude is available.
+        # TODO: The angular rate is currently unavailable. Using an estimate of 0 deg/s until a
+        # proper estimate of the angular rate is available.
+
         return [
             ProcessorDataPacket(
                 current_altitude=float(self._current_altitudes[i]),
-                vertical_velocity=float(self._vertical_velocities[i]),
-                horizontal_velocity=self._calculate_horizontal_velocity(
-                    float(self._vertical_velocities[i]),
-                    self._data_packets[i].est_tilt_angle_degrees,
-                    ),
+                vertical_velocity_meters_per_s=float(self._vertical_velocities[i]),
+                horizontal_velocity_meters_per_s=0.0,
                 tilt_angle_degrees=float(self._data_packets[i].est_tilt_angle_degrees),
-                angular_rate=0.0,
+                angular_rate_deg_per_s=0.0,
                 timestamp_seconds=float(self._data_packets[i].timestamp_seconds),
             )
             for i in range(len(self._data_packets))

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -243,6 +243,16 @@ class DataProcessor:
         # Get the pressure altitudes from the data points and zero out the initial altitude
         return altitudes
 
+    def _calculate_horizontal_velocity(self, vertical_velocity: float, tilt_angle_degrees: float,) -> float:
+        """
+        Calculates the horizontal velocity from the rocket's vertical velocity and tilt tilt angle.
+        """
+        angle_radians = np.radians(tilt_angle_degrees)
+        horizontal_velocity = vertical_velocity * np.tan(angle_radians)
+
+        # Get the current horizontal velocity
+        return horizontal_velocity
+
     def _calculate_time_differences(self) -> npt.NDArray[np.float64]:
         """
         Calculates the time difference between each data packet and the previous data packet.
@@ -279,6 +289,12 @@ class DataProcessor:
             ProcessorDataPacket(
                 current_altitude=float(self._current_altitudes[i]),
                 vertical_velocity=float(self._vertical_velocities[i]),
+                horizontal_velocity=self._calculate_horizontal_velocity(
+                    float(self._vertical_velocities[i]),
+                    self._data_packets[i].est_tilt_angle_degrees,
+                    ),
+                tilt_angle_degrees=float(self._data_packets[i].est_tilt_angle_degrees),
+                angular_rate=0.0,
                 timestamp_seconds=float(self._data_packets[i].timestamp_seconds),
             )
             for i in range(len(self._data_packets))

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -19,6 +19,7 @@ from airbrakes.constants import (
 from airbrakes.data_handling.packets.logger_data_packet import LoggerDataPacket
 from airbrakes.state import LandedState, StandbyState
 from airbrakes.utils import get_all_packets_from_queue
+from tests.test_packets.test_apogee_predictor_data_packet import apogee_predictor_data_packet
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
@@ -141,13 +142,25 @@ class Logger:
             # Apogee Predictor fields default to none if no packet is provided
             predicted_apogee = None
             height_used_for_prediction = None
-            velocity_used_for_prediction = None
+            vertical_velocity_meters_per_s_used_for_prediction = None
+            horizontal_velocity_meters_per_s_used_for_prediction = None
+            tilt_angle_degrees_used_for_prediction = None
+            angular_rate_deg_per_s_used_for_prediction = None
 
             if apogee_predictor_data_packet:
                 predicted_apogee = apogee_predictor_data_packet.predicted_apogee
                 height_used_for_prediction = apogee_predictor_data_packet.height_used_for_prediction
-                velocity_used_for_prediction = (
-                    apogee_predictor_data_packet.velocity_used_for_prediction
+                vertical_velocity_meters_per_s_used_for_prediction = (
+                    apogee_predictor_data_packet.vertical_velocity_meters_per_s_used_for_prediction
+                )
+                horizontal_velocity_meters_per_s_used_for_prediction = (
+                apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
+                )
+                tilt_angle_degrees_used_for_prediction = (
+                    apogee_predictor_data_packet.tilt_angle_degrees_used_for_prediction
+                )
+                angular_rate_deg_per_s_used_for_prediction = (
+                    apogee_predictor_data_packet.angular_rate_deg_per_s_used_for_prediction
                 )
 
             logger_packet = LoggerDataPacket(
@@ -184,7 +197,10 @@ class Logger:
                 # Apogee Predictor Data Packet Fields
                 predicted_apogee=predicted_apogee,
                 height_used_for_prediction=height_used_for_prediction,
-                velocity_used_for_prediction=velocity_used_for_prediction,
+                vertical_velocity_meters_per_s_used_for_prediction=vertical_velocity_meters_per_s_used_for_prediction,
+                horizontal_velocity_meters_per_s_used_for_prediction=horizontal_velocity_meters_per_s_used_for_prediction,
+                tilt_angle_degrees_used_for_prediction=tilt_angle_degrees_used_for_prediction,
+                angular_rate_deg_per_s_used_for_prediction=angular_rate_deg_per_s_used_for_prediction,
                 # Remaining Context Fields
                 retrieved_firm_packets=context_data_packet.retrieved_firm_packets,
                 apogee_predictor_queue_size=context_data_packet.apogee_predictor_queue_size,

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -152,7 +152,9 @@ class Logger:
                 vertical_velocity_meters_per_s_used_for_prediction = (
                     apogee_predictor_data_packet.vertical_velocity_meters_per_s_used_for_prediction
                 )
-                horizontal_velocity_meters_per_s_used_for_prediction = apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
+                horizontal_velocity_meters_per_s_used_for_prediction = (
+                    apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
+                )
                 tilt_angle_degrees_used_for_prediction = (
                     apogee_predictor_data_packet.tilt_angle_degrees_used_for_prediction
                 )

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -152,9 +152,11 @@ class Logger:
                 vertical_velocity_meters_per_s_used_for_prediction = (
                     apogee_predictor_data_packet.vertical_velocity_meters_per_s_used_for_prediction
                 )
+                # fmt: off
                 horizontal_velocity_meters_per_s_used_for_prediction = (
                     apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
                 )
+                # fmt: on
                 tilt_angle_degrees_used_for_prediction = (
                     apogee_predictor_data_packet.tilt_angle_degrees_used_for_prediction
                 )

--- a/airbrakes/data_handling/logger.py
+++ b/airbrakes/data_handling/logger.py
@@ -19,7 +19,6 @@ from airbrakes.constants import (
 from airbrakes.data_handling.packets.logger_data_packet import LoggerDataPacket
 from airbrakes.state import LandedState, StandbyState
 from airbrakes.utils import get_all_packets_from_queue
-from tests.test_packets.test_apogee_predictor_data_packet import apogee_predictor_data_packet
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
@@ -153,9 +152,7 @@ class Logger:
                 vertical_velocity_meters_per_s_used_for_prediction = (
                     apogee_predictor_data_packet.vertical_velocity_meters_per_s_used_for_prediction
                 )
-                horizontal_velocity_meters_per_s_used_for_prediction = (
-                apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
-                )
+                horizontal_velocity_meters_per_s_used_for_prediction = apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
                 tilt_angle_degrees_used_for_prediction = (
                     apogee_predictor_data_packet.tilt_angle_degrees_used_for_prediction
                 )

--- a/airbrakes/data_handling/packets/apogee_predictor_data_packet.py
+++ b/airbrakes/data_handling/packets/apogee_predictor_data_packet.py
@@ -12,9 +12,18 @@ class ApogeePredictorDataPacket(msgspec.Struct, tag=True, array_like=True):
     height_used_for_prediction: float
     """The altitude used for the apogee prediction in meters."""
 
-    velocity_used_for_prediction: float
+    vertical_velocity_meters_per_s_used_for_prediction: float
     """The vertical velocity used for the apogee prediction in meters per
     second."""
 
-    # TODO: implement once apogee prediction uses 3DOF
-    # pitch_used_for_prediction: float
+    horizontal_velocity_meters_per_s_used_for_prediction: float
+    """The horizontal velocity used for the apogee prediction in meters per
+    second."""
+
+    tilt_angle_degrees_used_for_prediction: float
+    """The tilt angle used for the apogee prediction in degrees."""
+
+    angular_rate_deg_per_s_used_for_prediction: float
+    """The angular rate used for the apogee prediction in degrees per
+    second."""
+

--- a/airbrakes/data_handling/packets/apogee_predictor_data_packet.py
+++ b/airbrakes/data_handling/packets/apogee_predictor_data_packet.py
@@ -26,4 +26,3 @@ class ApogeePredictorDataPacket(msgspec.Struct, tag=True, array_like=True):
     angular_rate_deg_per_s_used_for_prediction: float
     """The angular rate used for the apogee prediction in degrees per
     second."""
-

--- a/airbrakes/data_handling/packets/logger_data_packet.py
+++ b/airbrakes/data_handling/packets/logger_data_packet.py
@@ -49,7 +49,10 @@ class LoggerDataPacket(msgspec.Struct, array_like=True, kw_only=True):
     # Apogee Predictor Data Packet Fields
     predicted_apogee: float | None = None
     height_used_for_prediction: float | None = None
-    velocity_used_for_prediction: float | None = None
+    vertical_velocity_meters_per_s_used_for_prediction: float | None = None
+    horizontal_velocity_meters_per_s_used_for_prediction: float | None = None
+    tilt_angle_degrees_used_for_prediction: float | None = None
+    angular_rate_deg_per_s_used_for_prediction: float | None = None
 
     # Other fields in ContextDataPacket
     retrieved_firm_packets: int | None

--- a/airbrakes/data_handling/packets/processor_data_packet.py
+++ b/airbrakes/data_handling/packets/processor_data_packet.py
@@ -24,6 +24,21 @@ class ProcessorDataPacket(msgspec.Struct, array_like=True, tag=True):
     The vertical velocity of the rocket in meters per second.
     """
 
+    horizontal_velocity: float
+    """
+    The horizontal velocity of the rocket in meters per second.
+    """
+
+    tilt_angle_degrees: float
+    """
+    The total tilt angle of the rocket measured from the +Z axis.
+    """
+
+    angular_rate: float
+    """
+    The current angular rate of the rocket in degrees per second.
+    """
+
     timestamp_seconds: float
     """
     The timestamp of the packet in seconds.

--- a/airbrakes/data_handling/packets/processor_data_packet.py
+++ b/airbrakes/data_handling/packets/processor_data_packet.py
@@ -19,12 +19,12 @@ class ProcessorDataPacket(msgspec.Struct, array_like=True, tag=True):
     In other words, the altitude relative to the ground from the launch pad (AGL).
     """
 
-    vertical_velocity: float
+    vertical_velocity_meters_per_s: float
     """
     The vertical velocity of the rocket in meters per second.
     """
 
-    horizontal_velocity: float
+    horizontal_velocity_meters_per_s: float
     """
     The horizontal velocity of the rocket in meters per second.
     """
@@ -34,7 +34,7 @@ class ProcessorDataPacket(msgspec.Struct, array_like=True, tag=True):
     The total tilt angle of the rocket measured from the +Z axis.
     """
 
-    angular_rate: float
+    angular_rate_deg_per_s: float
     """
     The current angular rate of the rocket in degrees per second.
     """

--- a/airbrakes/mock/mock_firm.py
+++ b/airbrakes/mock/mock_firm.py
@@ -89,6 +89,8 @@ class MockFIRM(BaseFIRM):
             airbrakes.constants.ROCKET_DRY_MASS_KG = self.rocket_parameters.rocket_mass_kg
         if self.rocket_parameters.rocket_Cd is not None:
             airbrakes.constants.ROCKET_CD = self.rocket_parameters.rocket_Cd
+        if self.rocket_parameters.rocket_diameter_m is not None:
+            airbrakes.constants.ROCKET_DIAMETER_M = self.rocket_parameters.rocket_diameter_m
         if self.rocket_parameters.rocket_cross_sectional_area_m2 is not None:
             airbrakes.constants.ROCKET_CROSS_SECTIONAL_AREA_M2 = (
                 self.rocket_parameters.rocket_cross_sectional_area_m2

--- a/airbrakes/mock/mock_firm.py
+++ b/airbrakes/mock/mock_firm.py
@@ -98,7 +98,9 @@ class MockFIRM(BaseFIRM):
                 self.rocket_parameters.rocket_moment_of_inertia_kg_m2
             )
         if self.rocket_parameters.rocket_stab_margin_cal is not None:
-            airbrakes.constants.ROCKET_STAB_MARGIN_CAL = self.rocket_parameters.rocket_stab_margin_cal
+            airbrakes.constants.ROCKET_STAB_MARGIN_CAL = (
+                self.rocket_parameters.rocket_stab_margin_cal
+            )
         if self.rocket_parameters.rocket_cl_a is not None:
             airbrakes.constants.ROCKET_CL_A = self.rocket_parameters.rocket_cl_a
 

--- a/airbrakes/mock/mock_firm.py
+++ b/airbrakes/mock/mock_firm.py
@@ -22,6 +22,10 @@ class RocketParameters(msgspec.Struct):
     rocket_Cd: float | None
     rocket_mass_kg: float | None
     rocket_cross_sectional_area_m2: float | None
+    rocket_diameter_m: float | None
+    rocket_moment_of_inertia_kg_m2: float | None
+    rocket_stab_margin_cal: float | None
+    rocket_cl_a: float | None
 
 
 class MockFIRM(BaseFIRM):
@@ -89,6 +93,14 @@ class MockFIRM(BaseFIRM):
             airbrakes.constants.ROCKET_CROSS_SECTIONAL_AREA_M2 = (
                 self.rocket_parameters.rocket_cross_sectional_area_m2
             )
+        if self.rocket_parameters.rocket_moment_of_inertia_kg_m2 is not None:
+            airbrakes.constants.ROCKET_MOMENT_OF_INERTIA_KG_M2 = (
+                self.rocket_parameters.rocket_moment_of_inertia_kg_m2
+            )
+        if self.rocket_parameters.rocket_stab_margin_cal is not None:
+            airbrakes.constants.ROCKET_STAB_MARGIN_CAL = self.rocket_parameters.rocket_stab_margin_cal
+        if self.rocket_parameters.rocket_cl_a is not None:
+            airbrakes.constants.ROCKET_CL_A = self.rocket_parameters.rocket_cl_a
 
         # Set up a queue and thread
         self._queued_packets: queue.SimpleQueue[FIRMDataPacket | str] = queue.SimpleQueue()
@@ -178,6 +190,10 @@ class MockFIRM(BaseFIRM):
             rocket_Cd=rocket_data.get("rocket_Cd"),
             rocket_mass_kg=rocket_data.get("rocket_dry_mass_kg"),
             rocket_cross_sectional_area_m2=rocket_data.get("rocket_cross_sectional_area_m2"),
+            rocket_diameter_m=rocket_data.get("rocket_diameter_m"),
+            rocket_moment_of_inertia_kg_m2=rocket_data.get("rocket_moment_of_inertia_kg_m2"),
+            rocket_stab_margin_cal=rocket_data.get("rocket_stab_margin_cal"),
+            rocket_cl_a=rocket_data.get("rocket_cl_a"),
         )
 
     # ------------------------ THREAD METHODS -------------------------

--- a/launch_data/metadata.json
+++ b/launch_data/metadata.json
@@ -50,7 +50,7 @@
       "rocket_cross_sectional_area_m2": 0.0182414692475,
       "rocket_diameter_m": 0.1524,
       "rocket_moment_of_inertia_kg_m2": 11.45,
-      "rocket_stab_margin_cal": 0,
+      "rocket_stab_margin_cal": 3.3,
       "rocket_cl_a": 0.2,
       "motor": "L1390G-P"
     },

--- a/launch_data/metadata.json
+++ b/launch_data/metadata.json
@@ -6,6 +6,10 @@
       "rocket_Cd": 0.38,
       "rocket_dry_mass_kg": 16.848,
       "rocket_cross_sectional_area_m2": 0.0182414692475,
+      "rocket_diameter_m": 0.1524,
+      "rocket_moment_of_inertia_kg_m2": 11.26,
+      "rocket_stab_margin_cal": 2.82,
+      "rocket_cl_a": 0.2,
       "motor": "L1390G-P"
     },
     "launch_site": {
@@ -44,6 +48,10 @@
       "rocket_Cd": 0.393,
       "rocket_dry_mass_kg": 15.736,
       "rocket_cross_sectional_area_m2": 0.0182414692475,
+      "rocket_diameter_m": 0.1524,
+      "rocket_moment_of_inertia_kg_m2": 11.45,
+      "rocket_stab_margin_cal": 0,
+      "rocket_cl_a": 0.2,
       "motor": "L1390G-P"
     },
     "launch_site": {
@@ -82,6 +90,10 @@
       "rocket_Cd": 0.393,
       "rocket_dry_mass_kg": 17.05099,
       "rocket_cross_sectional_area_m2": 0.0182414692475,
+      "rocket_diameter_m": 0.1524,
+      "rocket_moment_of_inertia_kg_m2": 11.45,
+      "rocket_stab_margin_cal": 3.3,
+      "rocket_cl_a": 0.2,
       "motor": "L1390G-P"
     },
     "launch_site": {
@@ -120,6 +132,10 @@
       "rocket_Cd": 0.393,
       "rocket_dry_mass_kg": 16.601,
       "rocket_cross_sectional_area_m2": 0.0182414692475,
+      "rocket_diameter_m": 0.1524,
+      "rocket_moment_of_inertia_kg_m2": 11.45,
+      "rocket_stab_margin_cal": 3.24,
+      "rocket_cl_a": 0.2,
       "motor": "L1390G-P"
     },
     "launch_site": {

--- a/launch_data/metadata_schema.json
+++ b/launch_data/metadata_schema.json
@@ -20,6 +20,18 @@
                     "rocket_cross_sectional_area_m2": {
                         "type": ["number", "null"]
                     },
+                    "rocket_diameter_m": {
+                        "type": ["number", "null"]
+                    },
+                    "rocket_moment_of_inertia_kg_m2": {
+                        "type": ["number", "null"]
+                    },
+                    "rocket_stab_margin_cal": {
+                        "type": ["number", "null"]
+                    },
+                    "rocket_cl_a": {
+                        "type": ["number", "null"]
+                    },
                     "motor": {
                         "type": "string"
                     }
@@ -28,6 +40,10 @@
                     "rocket_dry_mass_kg",
                     "rocket_Cd",
                     "rocket_cross_sectional_area_m2",
+                    "rocket_diameter_m",
+                    "rocket_moment_of_inertia_kg_m2",
+                    "rocket_stab_margin_cal",
+                    "rocket_cl_a",
                     "motor"
                 ],
                 "additionalProperties": false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # Please see library docs for usage and installation on the Pi 4/5. You need to add
     # `dtoverlay=pwm-2chan` in /boot/firmware/config.txt.
     "rpi-hardware-pwm>=0.3.0",
-    "hprm>=0.1.7",
+    "hprm>=0.2.0",
     "firm-client>=1.2.2",
     "pi-ina219>=1.4.1",
     "gpiod>=2.4.2; platform_system == 'Linux'",

--- a/tests/test_components/test_apogee_predictor.py
+++ b/tests/test_components/test_apogee_predictor.py
@@ -64,7 +64,7 @@ class TestApogeePredictor:
         ("firm_data_packets", "expected_apogee"),
         [
             # Hovering case: v = 0, a ≈ g, should give apogee basically at current altitude.
-            # TODO: Investgate why HPRM panics when vertical velocity is exactly 0.0
+            # TODO: Investigate why HPRM panics when vertical velocity is exactly 0.0
             # For this reason, a very small vertical velocity of 0.01 m/s was used.
             (
                 [

--- a/tests/test_components/test_apogee_predictor.py
+++ b/tests/test_components/test_apogee_predictor.py
@@ -1,3 +1,4 @@
+import math
 import queue
 import threading
 import time
@@ -64,8 +65,17 @@ class TestApogeePredictor:
         ("firm_data_packets", "expected_apogee"),
         [
             # Hovering case: v = 0, a ≈ g, should give apogee basically at current altitude.
+            # TODO: Investgate why HPRM panics when vertical velocity is exactly 0.0
+            # For this reason, We used a very small vertical velocity of 0.01 m/s.
             (
-                [make_processor_data_packet_zeroed(current_altitude=100.0, vertical_velocity=0.0)]
+                [make_processor_data_packet_zeroed(
+                    current_altitude=100.0,
+                    vertical_velocity_meters_per_s=0.01,
+                    horizontal_velocity_meters_per_s=0.0,
+                    tilt_angle_degrees=0.0,
+                    angular_rate_deg_per_s=0.0,
+                    )
+                ]
                 * 10,
                 100,
             ),
@@ -75,11 +85,14 @@ class TestApogeePredictor:
                         current_altitude=float(
                             i**3 / 15000 - i**2 / 20 - i**2 * 9.798 / 200 + 20 * i + 100
                         ),
-                        vertical_velocity=float(i**2 / 500 - i - 9.798 * i / 10 + 200),
+                        vertical_velocity_meters_per_s=float(i**2 / 500 - i - 9.798 * i / 10 + 200),
+                        horizontal_velocity_meters_per_s=0.0,
+                        tilt_angle_degrees=float(15 * i/ 69),
+                        angular_rate_deg_per_s=0.0,
                     )
                     for i in range(70)
                 ],
-                1272.556161741228,
+                1282.3508299189677,
             ),
         ],
         ids=["at_apogee", "start_of_coast_phase"],
@@ -99,9 +112,13 @@ class TestApogeePredictor:
             * The height/velocity used in the prediction come from the last packet.
             * The predicted apogee matches an expected (precomputed) value.
         """
-        monkeypatch.setattr("airbrakes.constants.ROCKET_DRY_MASS_KG", 4.937)
-        monkeypatch.setattr("airbrakes.constants.ROCKET_CD", 0.45)
-        monkeypatch.setattr("airbrakes.constants.ROCKET_CROSS_SECTIONAL_AREA_M2", 0.00810731966)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_DRY_MASS_KG", 16.601)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_CD", 0.393)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_DIAMETER_M", 0.1524)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_CROSS_SECTIONAL_AREA_M2", 0.0182414692475)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_MOMENT_OF_INERTIA_KG_M2", 11.45)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_STAB_MARGIN_CAL", 3.24)
+        monkeypatch.setattr("airbrakes.constants.ROCKET_CL_A", 0.2)
         apogee_predictor.start()
 
         # Feed all packets into the predictor, one by one
@@ -125,8 +142,14 @@ class TestApogeePredictor:
         last_packet = firm_data_packets[-1]
 
         assert prediction.height_used_for_prediction == pytest.approx(last_packet.current_altitude)
-        assert prediction.velocity_used_for_prediction == pytest.approx(
-            last_packet.vertical_velocity
+        assert prediction.vertical_velocity_meters_per_s_used_for_prediction == pytest.approx(
+            last_packet.vertical_velocity_meters_per_s
+        )
+        assert prediction.horizontal_velocity_meters_per_s_used_for_prediction == pytest.approx(
+            last_packet.horizontal_velocity_meters_per_s
+        )
+        assert prediction.tilt_angle_degrees_used_for_prediction == pytest.approx(
+            last_packet.tilt_angle_degrees
         )
 
         assert prediction.predicted_apogee == pytest.approx(expected_apogee, rel=10e-4)

--- a/tests/test_components/test_apogee_predictor.py
+++ b/tests/test_components/test_apogee_predictor.py
@@ -1,4 +1,3 @@
-import math
 import queue
 import threading
 import time
@@ -66,14 +65,15 @@ class TestApogeePredictor:
         [
             # Hovering case: v = 0, a ≈ g, should give apogee basically at current altitude.
             # TODO: Investgate why HPRM panics when vertical velocity is exactly 0.0
-            # For this reason, We used a very small vertical velocity of 0.01 m/s.
+            # For this reason, a very small vertical velocity of 0.01 m/s was used.
             (
-                [make_processor_data_packet_zeroed(
-                    current_altitude=100.0,
-                    vertical_velocity_meters_per_s=0.01,
-                    horizontal_velocity_meters_per_s=0.0,
-                    tilt_angle_degrees=0.0,
-                    angular_rate_deg_per_s=0.0,
+                [
+                    make_processor_data_packet_zeroed(
+                        current_altitude=100.0,
+                        vertical_velocity_meters_per_s=0.01,
+                        horizontal_velocity_meters_per_s=0.0,
+                        tilt_angle_degrees=0.0,
+                        angular_rate_deg_per_s=0.0,
                     )
                 ]
                 * 10,
@@ -87,7 +87,7 @@ class TestApogeePredictor:
                         ),
                         vertical_velocity_meters_per_s=float(i**2 / 500 - i - 9.798 * i / 10 + 200),
                         horizontal_velocity_meters_per_s=0.0,
-                        tilt_angle_degrees=float(15 * i/ 69),
+                        tilt_angle_degrees=float(15 * i / 69),
                         angular_rate_deg_per_s=0.0,
                     )
                     for i in range(70)

--- a/tests/test_components/test_data_processor.py
+++ b/tests/test_components/test_data_processor.py
@@ -87,11 +87,17 @@ class TestDataProcessor:
     packets = [
         make_processor_data_packet_zeroed(
             current_altitude=1,
-            vertical_velocity=1,
+            vertical_velocity_meters_per_s=1,
+            horizontal_velocity_meters_per_s=1,
+            tilt_angle_degrees=1,
+            angular_rate_deg_per_s=1,
         ),
         make_processor_data_packet_zeroed(
             current_altitude=2,
-            vertical_velocity=2,
+            vertical_velocity_meters_per_s=2,
+            horizontal_velocity_meters_per_s=2,
+            tilt_angle_degrees=2,
+            angular_rate_deg_per_s=2,
         ),
     ]
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -448,7 +448,19 @@ class TestContext:
             context.most_recent_apogee_predictor_data_packet.height_used_for_prediction is not None
         )
         assert (
-            context.most_recent_apogee_predictor_data_packet.velocity_used_for_prediction
+            context.most_recent_apogee_predictor_data_packet.vertical_velocity_meters_per_s_used_for_prediction
+            is not None
+        )
+        assert (
+            context.most_recent_apogee_predictor_data_packet.horizontal_velocity_meters_per_s_used_for_prediction
+            is not None
+        )
+        assert (
+            context.most_recent_apogee_predictor_data_packet.tilt_angle_degrees_used_for_prediction
+            is not None
+        )
+        assert (
+            context.most_recent_apogee_predictor_data_packet.angular_rate_deg_per_s_used_for_prediction
             is not None
         )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -251,16 +251,41 @@ class TestIntegration:
             .to_list()
         )
 
-        velocities_used_for_prediction_in_coast = (
-            coast_df.filter(pl.col("velocity_used_for_prediction").is_not_null())
-            .get_column("velocity_used_for_prediction")
+        vertical_velocities_meters_per_s_used_for_prediction_in_coast = (
+            coast_df.filter(
+                pl.col("vertical_velocity_meters_per_s_used_for_prediction").is_not_null()
+            )
+            .get_column("vertical_velocity_meters_per_s_used_for_prediction")
+            .to_list()
+        )
+
+        horizontal_velocities_meters_per_s_used_for_prediction_in_coast = (
+            coast_df.filter(
+                pl.col("horizontal_velocity_meters_per_s_used_for_prediction").is_not_null()
+            )
+            .get_column("horizontal_velocity_meters_per_s_used_for_prediction")
+            .to_list()
+        )
+
+        tilt_angles_degrees_used_for_prediction_in_coast = (
+            coast_df.filter(pl.col("tilt_angle_degrees_used_for_prediction").is_not_null())
+            .get_column("tilt_angle_degrees_used_for_prediction")
+            .to_list()
+        )
+
+        angular_rates_deg_per_s_used_for_prediction_in_coast = (
+            coast_df.filter(pl.col("angular_rate_deg_per_s_used_for_prediction").is_not_null())
+            .get_column("angular_rate_deg_per_s_used_for_prediction")
             .to_list()
         )
 
         # Predicted apogees and values used for prediction should be present in coast state
         assert len(pred_apogees_in_coast) > 0
         assert len(heights_used_for_prediction_in_coast) > 0
-        assert len(velocities_used_for_prediction_in_coast) > 0
+        assert len(vertical_velocities_meters_per_s_used_for_prediction_in_coast) > 0
+        assert len(horizontal_velocities_meters_per_s_used_for_prediction_in_coast) > 0
+        assert len(tilt_angles_degrees_used_for_prediction_in_coast) > 0
+        assert len(angular_rates_deg_per_s_used_for_prediction_in_coast) > 0
 
         # Check if extensions are valid floats
         valid_extensions = [

--- a/tests/test_packets/test_apogee_predictor_data_packet.py
+++ b/tests/test_packets/test_apogee_predictor_data_packet.py
@@ -10,7 +10,10 @@ def apogee_predictor_data_packet():
     return ApogeePredictorDataPacket(
         predicted_apogee=TestApogeePredictorDataPacket.predicted_apogee,
         height_used_for_prediction=TestApogeePredictorDataPacket.height_used_for_prediction,
-        velocity_used_for_prediction=TestApogeePredictorDataPacket.velocity_used_for_prediction,
+        vertical_velocity_meters_per_s_used_for_prediction=TestApogeePredictorDataPacket.vertical_velocity_meters_per_s_used_for_prediction,
+        horizontal_velocity_meters_per_s_used_for_prediction=TestApogeePredictorDataPacket.horizontal_velocity_meters_per_s_used_for_prediction,
+        tilt_angle_degrees_used_for_prediction=TestApogeePredictorDataPacket.tilt_angle_degrees_used_for_prediction,
+        angular_rate_deg_per_s_used_for_prediction=TestApogeePredictorDataPacket.angular_rate_deg_per_s_used_for_prediction,
     )
 
 
@@ -19,13 +22,27 @@ class TestApogeePredictorDataPacket:
 
     predicted_apogee = 0.45
     height_used_for_prediction = 1.23
-    velocity_used_for_prediction = 4.56
+    vertical_velocity_meters_per_s_used_for_prediction = 4.56
+    horizontal_velocity_meters_per_s_used_for_prediction = 7.89
+    tilt_angle_degrees_used_for_prediction = 12.34
+    angular_rate_deg_per_s_used_for_prediction = 56.78
 
     def test_init(self, apogee_predictor_data_packet):
         packet = apogee_predictor_data_packet
         assert packet.predicted_apogee == self.predicted_apogee
         assert packet.height_used_for_prediction == self.height_used_for_prediction
-        assert packet.velocity_used_for_prediction == self.velocity_used_for_prediction
+        assert packet.vertical_velocity_meters_per_s_used_for_prediction == (
+            self.vertical_velocity_meters_per_s_used_for_prediction
+        )
+        assert packet.horizontal_velocity_meters_per_s_used_for_prediction == (
+            self.horizontal_velocity_meters_per_s_used_for_prediction
+        )
+        assert packet.tilt_angle_degrees_used_for_prediction == (
+            self.tilt_angle_degrees_used_for_prediction
+        )
+        assert packet.angular_rate_deg_per_s_used_for_prediction == (
+            self.angular_rate_deg_per_s_used_for_prediction
+        )
 
     def test_required_args(self):
         with pytest.raises(TypeError):

--- a/tests/test_packets/test_processor_data_packet.py
+++ b/tests/test_packets/test_processor_data_packet.py
@@ -7,7 +7,7 @@ from airbrakes.data_handling.packets.processor_data_packet import ProcessorDataP
 def processor_data_packet():
     return ProcessorDataPacket(
         current_altitude=TestProcessorDataPacket.current_altitude,
-        vertical_velocity=TestProcessorDataPacket.vertical_velocity,
+        vertical_velocity_meters_per_s=TestProcessorDataPacket.vertical_velocity,
         timestamp_seconds=TestProcessorDataPacket.timestamp_seconds,
     )
 

--- a/tests/test_packets/test_processor_data_packet.py
+++ b/tests/test_packets/test_processor_data_packet.py
@@ -7,7 +7,10 @@ from airbrakes.data_handling.packets.processor_data_packet import ProcessorDataP
 def processor_data_packet():
     return ProcessorDataPacket(
         current_altitude=TestProcessorDataPacket.current_altitude,
-        vertical_velocity_meters_per_s=TestProcessorDataPacket.vertical_velocity,
+        vertical_velocity_meters_per_s=TestProcessorDataPacket.vertical_velocity_meters_per_s,
+        horizontal_velocity_meters_per_s=TestProcessorDataPacket.horizontal_velocity_meters_per_s,
+        tilt_angle_degrees=TestProcessorDataPacket.tilt_angle_degrees,
+        angular_rate_deg_per_s=TestProcessorDataPacket.angular_rate_deg_per_s,
         timestamp_seconds=TestProcessorDataPacket.timestamp_seconds,
     )
 
@@ -18,13 +21,19 @@ class TestProcessorDataPacket:
     """
 
     current_altitude = 0.0
-    vertical_velocity = 0.0
+    vertical_velocity_meters_per_s = 0.0
+    horizontal_velocity_meters_per_s = 0.0
+    tilt_angle_degrees = 0.0
+    angular_rate_deg_per_s = 0.0
     timestamp_seconds = 0.0
 
     def test_init(self, processor_data_packet):
         packet = processor_data_packet
         assert packet.current_altitude == self.current_altitude
-        assert packet.vertical_velocity == self.vertical_velocity
+        assert packet.vertical_velocity_meters_per_s == self.vertical_velocity_meters_per_s
+        assert packet.horizontal_velocity_meters_per_s == self.horizontal_velocity_meters_per_s
+        assert packet.tilt_angle_degrees == self.tilt_angle_degrees
+        assert packet.angular_rate_deg_per_s == self.angular_rate_deg_per_s
         assert packet.timestamp_seconds == self.timestamp_seconds
 
     def test_required_args(self):

--- a/uv.lock
+++ b/uv.lock
@@ -17,12 +17,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T05:03:40.755416519Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-hprm = { timestamp = "2026-04-18T05:03:39.755437093Z", span = "PT1S" }
-firm-client = { timestamp = "2026-04-18T05:03:39.755427519Z", span = "PT1S" }
+hprm = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
+firm-client = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -164,7 +164,7 @@ requires-dist = [
     { name = "firm-client", specifier = ">=1.2.2" },
     { name = "gpiod", marker = "sys_platform == 'linux'", specifier = ">=2.4.2" },
     { name = "gpiozero" },
-    { name = "hprm", specifier = ">=0.1.7" },
+    { name = "hprm", specifier = ">=0.2.0" },
     { name = "lgpio", marker = "extra == 'encoder'", specifier = ">=0.2.2.0" },
     { name = "msgspec" },
     { name = "numpy" },
@@ -363,14 +363,16 @@ wheels = [
 
 [[package]]
 name = "hprm"
-version = "0.1.7"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/9a/22e70ad216b6a8d303c75ac78aed1800bdd682cee25d211754a68b25f31a/hprm-0.1.7.tar.gz", hash = "sha256:70f1ff1547fbd10277da156a970b8abce1acf7724aef3f435240b5e81219198f", size = 161285, upload-time = "2026-01-26T08:46:01.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/56/61f26a815e9181e943fdaf43edc36ad84d30eb0902a393652197622312bb/hprm-0.2.0.tar.gz", hash = "sha256:542485e903f33a57892af5169a0446e2a1ba651c22f3312e5a743570692bb462", size = 195798, upload-time = "2026-06-20T05:19:46.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/f6/fc306c918716253e117501d9a87a05d995cd010e4b26c3e2b3bedaffa7ef/hprm-0.1.7-cp314-cp314-manylinux_2_31_aarch64.whl", hash = "sha256:b56d61d24f3e4707c4722d210e1b0a6b7d91ff3c0f595f9d81670ca8c3552c54", size = 284081, upload-time = "2026-01-26T08:45:56.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/7c5357878b6575e90c3211bf3ffe895778d33bcadaf83eff6fcb223460a6/hprm-0.1.7-cp314-cp314-win_amd64.whl", hash = "sha256:4d437748e2ebb329a0e337596d0b16b614ec06edf5b1acac66fa068450817270", size = 393426, upload-time = "2026-01-26T08:45:58.143Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/f8a607ac42e037ebbe6d73a6556debf5d991e0c88d998f456a9de18c9316/hprm-0.1.7-cp314-cp314t-manylinux_2_31_aarch64.whl", hash = "sha256:a48a8de06fa03df9cf9a2972b07d249d1c1c6f6fa6b96014eff7bd72eca476fa", size = 283536, upload-time = "2026-01-26T08:45:59.442Z" },
-    { url = "https://files.pythonhosted.org/packages/67/cd/9f3b4360864fe15c430d76ef9cb66d42588e1913454aa7c8e8f8fc6e54ad/hprm-0.1.7-cp314-cp314t-win_amd64.whl", hash = "sha256:7bd1f5657480c40f2a910a11c329f42eb10d40c8aa970fc75e4acd42e3d1a41b", size = 179313, upload-time = "2026-01-26T08:46:00.434Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/4e/2a1cc23e40f3d688f7e7ea3e2c2dec7c7937218ebe44149677ccc9294c00/hprm-0.2.0-cp314-cp314-manylinux_2_31_aarch64.whl", hash = "sha256:9cfd29145791d65e1c0b8ae1f90ab4dc78cb67cec83bf0f65f2b470ac0c7a6c6", size = 290212, upload-time = "2026-06-20T05:20:57.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/48/3826175eaf5843a566b5ecadb7e62526e7c1209e2816e0755e4e6003a1d6/hprm-0.2.0-cp314-cp314-manylinux_2_31_x86_64.whl", hash = "sha256:b2b7e7d6a10d1224eb10681f9a679fa4547bddbad876fb307a99c59c09800542", size = 298530, upload-time = "2026-06-20T08:37:16.212Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a0/12993dc97137506d62f851fb3a1613b5a95745eb8611beeca4ec58d8ae26/hprm-0.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:45ddcc80638548e51648f66008f5cd9c1fbed84620cb2abb6ce287f8716f28d8", size = 182490, upload-time = "2026-06-20T05:20:49.935Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/ce8712d0fd813d22e3cbc94738dd3caa4c07430b0c84676589de38e63f6c/hprm-0.2.0-cp314-cp314t-manylinux_2_31_aarch64.whl", hash = "sha256:ae270d6681c785fec8e186ef4de464fa5c3947ed425ec00f37f24d9bddde94ea", size = 289447, upload-time = "2026-06-20T05:19:41.871Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/19/505bd99560e3d2133486a93f059c8808de6e8e0464e1031942f4f2a97498/hprm-0.2.0-cp314-cp314t-manylinux_2_31_x86_64.whl", hash = "sha256:505e738938a032eb2ab62f58678ad2c18cee70da9a7378cbb5db9a2ef63b8ee9", size = 298862, upload-time = "2026-06-20T08:36:49.679Z" },
+    { url = "https://files.pythonhosted.org/packages/92/40/7323ba1dd67ff30119e3d93ad646816b33d1099edaa63f0486f4bf7b3275/hprm-0.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5cded711cfee7cc3349282781e8407b773fe8b9f3c887a7cd59b2d37b8e51d52", size = 182758, upload-time = "2026-06-20T05:19:54.065Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updated the HPRM integration to use the new 3DOF API.

Changes:
- Updated Rocket construction for HPRM 0.2.x
- Added new rocket constants required for 3DOF
- Switched InitialState1DOF to InitialState3DOF
- Added horizontal velocity, tilt angle, and angular rate support to ProcessorDataPacket
- Updated HPRM dependency

Current status:
- Project builds successfully
- `uv run mock` executes successfully
- Remaining issue: predicted apogee becomes unstable near the coast/freefall transition. Looking for feedback on whether the InitialState3DOF inputs (especially angle and horizontal velocity) are being constructed correctly.