### PR TITLE
Fixed a problem where we were using integrated altitude

### DIFF
--- a/airbrakes/constants.py
+++ b/airbrakes/constants.py
@@ -241,7 +241,7 @@ it to have landed.
 # Apogee Prediction Configuration
 # -------------------------------------------------------
 
-TARGET_APOGEE_METERS = convert_ft_to_m(4000.0)
+TARGET_APOGEE_METERS = convert_ft_to_m(40000.0)
 """The target apogee in meters that we want the rocket to reach.
 
 This is used with our bang-bang controller to determine when to extend

--- a/airbrakes/context.py
+++ b/airbrakes/context.py
@@ -6,7 +6,7 @@ rocket.
 import time
 from typing import TYPE_CHECKING
 
-from airbrakes.constants import BUSY_WAIT_SECONDS
+from airbrakes.constants import BUSY_WAIT_SECONDS, ServoExtension
 from airbrakes.data_handling.packets.context_data_packet import ContextDataPacket
 from airbrakes.data_handling.packets.servo_data_packet import ServoDataPacket
 from airbrakes.state import StandbyState, State
@@ -89,8 +89,8 @@ class Context:
         self.firm_data_packets: list[FIRMDataPacket] = []
         self.processor_data_packets: list[ProcessorDataPacket] = []
         self.most_recent_apogee_predictor_data_packet: ApogeePredictorDataPacket | None = None
-        self.context_data_packet: ContextDataPacket = None
-        self.servo_data_packet: ServoDataPacket = None
+        self.context_data_packet: ContextDataPacket | None = None
+        self.servo_data_packet: ServoDataPacket | None = None
 
         # Keeps track of the launch time, used for calculating convergence time
         self.launch_time_seconds: float = 0
@@ -168,13 +168,16 @@ class Context:
         # Create Context Data Packets representing the current state of the air brakes system:
         self.generate_data_packets()
 
-        # Logs all the packet types from each of the relevant processes
-        self.logger.log(
-            self.context_data_packet,
-            self.servo_data_packet,
-            self.firm_data_packets,
-            self.most_recent_apogee_predictor_data_packet,
-        )
+        # This if statement is just because my ide is being dumb, but it's not possible for them to 
+        # be None here
+        if self.context_data_packet is not None and self.servo_data_packet is not None:
+            # Logs all the packet types from each of the relevant processes
+            self.logger.log(
+                self.context_data_packet,
+                self.servo_data_packet,
+                self.firm_data_packets,
+                self.most_recent_apogee_predictor_data_packet,
+            )
 
     def extend_airbrakes(self) -> None:
         """Extends the air brakes to the maximum extension."""
@@ -183,8 +186,13 @@ class Context:
 
     def retract_airbrakes(self) -> None:
         """Retracts the air brakes to the minimum extension."""
-        self.data_processor.prepare_for_retracting_airbrakes()
-        self.servo.set_retracted()
+        # We don't want to retract the air brakes if they are already retracted
+        if self.servo.current_extension in (
+            ServoExtension.MAX_EXTENSION,
+            ServoExtension.MAX_NO_BUZZ,
+        ):
+            self.data_processor.prepare_for_retracting_airbrakes()
+            self.servo.set_retracted()
 
     def predict_apogee(self) -> None:
         """

--- a/airbrakes/context.py
+++ b/airbrakes/context.py
@@ -170,7 +170,7 @@ class Context:
         # Create Context Data Packets representing the current state of the air brakes system:
         self.generate_data_packets()
 
-        # This if statement is just because my ide is being dumb, but it's not possible for them to 
+        # This if statement is just because my ide is being dumb, but it's not possible for them to
         # be None here
         if self.context_data_packet is not None and self.servo_data_packet is not None:
             # Logs all the packet types from each of the relevant processes

--- a/airbrakes/context.py
+++ b/airbrakes/context.py
@@ -111,6 +111,8 @@ class Context:
         self.logger.start()
         self.apogee_predictor.start()
         self.servo.start()
+        # TODO: once we merge Manu's PR we can move this into the servo.start method
+        self.servo.set_retracted()
 
         if wait_for_start:
             # Wait for all processes to start. It is assumed that once FIRM is running, all other

--- a/airbrakes/data_handling/data_processor.py
+++ b/airbrakes/data_handling/data_processor.py
@@ -229,15 +229,20 @@ class DataProcessor:
             altitudes = self._previous_altitude + np.cumsum(
                 self._vertical_velocities * self._time_differences
             )
-        else:
+        elif self._initial_altitude is not None:
             altitudes = np.array(
                 [
                     data_packet.est_position_z_meters - self._initial_altitude
                     for data_packet in self._data_packets
                 ],
             )
+        else:
+            # If we don't have an initial altitude, we just use the raw altitudes .-.
+            altitudes = np.array(
+                [data_packet.est_position_z_meters for data_packet in self._data_packets],
+            )
 
-            # Update the stored previous altitude for the next calculation.
+        # Update the stored previous altitude for the next calculation.
         self._previous_altitude = altitudes[-1]
 
         # Get the pressure altitudes from the data points and zero out the initial altitude

--- a/launch_data/metadata.json
+++ b/launch_data/metadata.json
@@ -150,6 +150,6 @@
       "flight_length_seconds": 98.0,
       "target_apogee_meters": 1402.1
     },
-    "flight_description": "This was our 2025-2026 competition launch for NASA Student Launch. We were the 3rd rocket in the second volley. Our target apogee was 4600 ft and we hit 4606 ft, winning the altitude award. Our flight performed well with recovery working nominally. Due to a malfunction in FIRM, airbrakes over predicted apogee, resulting in airbrakes staying retracted for most of the flight. Due to sheer luck, our rocket was very close to hitting apogee, and once FIRM corrected its data, airbrakes briefly deployed near apogee."
+    "flight_description": "This was our 2025-2026 competition launch for NASA Student Launch. We were the 3rd rocket in the second volley. Our target apogee was 4600 ft and we hit 4606 ft, winning the altitude award. Our flight performed well with recovery working nominally. Due to a malfunction in FIRM, airbrakes under predicted apogee, resulting in airbrakes staying retracted for most of the flight. Due to sheer luck, our rocket was very close to hitting apogee, and once FIRM corrected its data, airbrakes briefly deployed near apogee."
   }
 }

--- a/tests/test_components/test_state.py
+++ b/tests/test_components/test_state.py
@@ -81,7 +81,7 @@ class TestState:
 
     def test_init(self, state, context):
         assert state.context == context
-        assert context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
         assert issubclass(state.__class__, ABC)
 
     def test_name(self, state):
@@ -169,7 +169,7 @@ class TestMotorBurnState:
         )
         motor_burn_state.update()
         assert isinstance(motor_burn_state.context.state, expected_state)
-        assert motor_burn_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert motor_burn_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
 
     # def test_motor_burn_fallback(self, motor_burn_state):
     #     """
@@ -197,7 +197,7 @@ class TestCoastState:
 
     def test_init(self, coast_state, context):
         assert coast_state.context == context
-        assert coast_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert coast_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
         assert issubclass(coast_state.__class__, State)
 
     def test_name(self, coast_state):
@@ -213,17 +213,17 @@ class TestCoastState:
             "airbrakes_ext",
         ),
         [
-            (200.0, 200.0, 100.0, 300.0, CoastState, ServoExtension.MIN_EXTENSION),
-            (100.0, 150.0, -20.0, 151.0, FreeFallState, ServoExtension.MIN_EXTENSION),
-            (100.0, 400.0, 140.1, 5000.1, CoastState, ServoExtension.MIN_EXTENSION),
-            (200.1, 200.1, 0.0, 200.1, CoastState, ServoExtension.MIN_EXTENSION),
+            (200.0, 200.0, 100.0, 300.0, CoastState, ServoExtension.MIN_NO_BUZZ),
+            (100.0, 150.0, -20.0, 151.0, FreeFallState, ServoExtension.MIN_NO_BUZZ),
+            (100.0, 400.0, 140.1, 5000.1, CoastState, ServoExtension.MIN_NO_BUZZ),
+            (200.1, 200.1, 0.0, 200.1, CoastState, ServoExtension.MIN_NO_BUZZ),
             (
                 200.1 * MAX_ALTITUDE_THRESHOLD,
                 200.1,
                 0.0,
                 200.1,
                 FreeFallState,
-                ServoExtension.MIN_EXTENSION,
+                ServoExtension.MIN_NO_BUZZ,
             ),
         ],
         ids=[
@@ -271,9 +271,9 @@ class TestCoastState:
         ),
         [
             (1100.0, 1130.2, ServoExtension.MAX_EXTENSION),
-            (1152.1, 1150.1, ServoExtension.MIN_EXTENSION),
-            (1168.1, 1160.1, ServoExtension.MIN_EXTENSION),
-            (1170.1, 1170.1, ServoExtension.MIN_EXTENSION),
+            (1152.1, 1150.1, ServoExtension.MIN_NO_BUZZ),
+            (1168.1, 1160.1, ServoExtension.MIN_NO_BUZZ),
+            (1170.1, 1170.1, ServoExtension.MIN_NO_BUZZ),
             (1189.4, 1190.1, ServoExtension.MAX_EXTENSION),
             (1191.9, 1200.5, ServoExtension.MAX_EXTENSION),
         ],
@@ -357,7 +357,7 @@ class TestCoastState:
         """
         assert not coast_state.context.most_recent_apogee_predictor_data_packet
         coast_state.update()
-        assert coast_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert coast_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
 
     def test_update_retract_airbrakes_from_extended(self, coast_state, monkeypatch):
         """
@@ -402,7 +402,7 @@ class TestFreeFallState:
 
     def test_init(self, free_fall_state, context):
         assert free_fall_state.context == context
-        assert free_fall_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert free_fall_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
         assert issubclass(free_fall_state.__class__, State)
 
     def test_name(self, free_fall_state):
@@ -473,7 +473,7 @@ class TestFreeFallState:
         )
         free_fall_state.update()
         assert isinstance(free_fall_state.context.state, expected_state)
-        assert free_fall_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert free_fall_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
 
 
 class TestLandedState:
@@ -486,7 +486,7 @@ class TestLandedState:
 
     def test_init(self, landed_state, context):
         assert landed_state.context == context
-        assert landed_state.context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert landed_state.context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
         assert issubclass(landed_state.__class__, State)
 
     def test_name(self, landed_state):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -37,7 +37,7 @@ class TestContext:
             assert getattr(inst, attr, "err") != "err", f"got extra slot '{attr}'"
 
     def test_init(self, context):
-        assert context.servo.current_extension == ServoExtension.MIN_EXTENSION
+        assert context.servo.current_extension == ServoExtension.MIN_NO_BUZZ
         assert isinstance(context.data_processor, DataProcessor)
         assert isinstance(context.state, StandbyState)
         assert isinstance(context.apogee_predictor, ApogeePredictor)
@@ -64,8 +64,8 @@ class TestContext:
         assert context.firm.is_running
         assert context.logger.is_running
         assert context.apogee_predictor.is_running
-        # Servo PWM should be live with the MIN_NO_BUZZ duty cycle after start()
-        expected_duty_cycle = Servo._angle_to_duty_cycle(ServoExtension.MIN_NO_BUZZ.value)
+        # Servo PWM should be live with the MIN_EXTENSION duty cycle after start()
+        expected_duty_cycle = Servo._angle_to_duty_cycle(ServoExtension.MIN_EXTENSION.value)
         assert context.servo.servo.duty_cycle == pytest.approx(expected_duty_cycle)
         context.stop()
 
@@ -464,7 +464,7 @@ class TestContext:
         assert context.context_data_packet.update_timestamp_ns == pytest.approx(
             time.time_ns(), rel=1e9
         )
-        assert context.servo_data_packet.set_extension == ServoExtension.MIN_EXTENSION
+        assert context.servo_data_packet.set_extension == ServoExtension.MIN_NO_BUZZ
 
     def test_benchmark_airbrakes_update(self, context, benchmark, random_data_mock_firm):
         """Benchmark the update method of the airbrakes system."""


### PR DESCRIPTION
We were using integrated altitude whenever we retracted airbrakes, which was happening at each state change. We still say to retract the airbrakes at each state change, but now they will only actually retract if they were extended.

Closes #354 